### PR TITLE
Fix typo in Fork documentation

### DIFF
--- a/website/docs/operations/06-fork.mdx
+++ b/website/docs/operations/06-fork.mdx
@@ -1,6 +1,6 @@
 import OperationOutputs from '@site/src/components/OperationOutputs';
 
-# Loops
+# Fork
 
 ```scala file=./main/scala/workflows4s/example/docs/ForkExample.scala start=start_doc end=end_doc
 ```


### PR DESCRIPTION
The title of the fork page was called "Loops", which was a bit confusing.

![image](https://github.com/user-attachments/assets/fb8941d4-723c-4f79-b15c-37cfa626ab57)
