### PR TITLE
Make `PostgresRuntime` "unresourceful" again

### DIFF
--- a/workflows4s-doobie/src/test/scala/workflows4s/doobie/postgres/PostgresRuntimeTest.scala
+++ b/workflows4s-doobie/src/test/scala/workflows4s/doobie/postgres/PostgresRuntimeTest.scala
@@ -21,14 +21,11 @@ class PostgresRuntimeTest extends AnyFreeSpec with PostgresSuite {
         .handleEvent((_, _) => State())
         .done
 
-      PostgresRuntime
-        .default(wio, State(), noopCodec(Event()), xa, NoOpKnockerUpper.Agent)
-        .use(runtime => {
-          val workflowInstance = runtime.createInstance(WorkflowId(1)).unsafeRunSync()
-          // this used to throw due to leaked LiftIO
-          workflowInstance.wakeup()
-        })
-        .unsafeRunSync()
+      val runtime          = PostgresRuntime.default(wio, State(), noopCodec(Event()), xa, NoOpKnockerUpper.Agent)
+      val workflowInstance = runtime.createInstance(WorkflowId(1)).unsafeRunSync()
+
+      // this used to throw due to leaked LiftIO
+      workflowInstance.wakeup().unsafeRunSync()
     }
   }
 

--- a/workflows4s-example/src/main/scala/workflows4s/example/docs/doobie/PostgresExample.scala
+++ b/workflows4s-example/src/main/scala/workflows4s/example/docs/doobie/PostgresExample.scala
@@ -8,10 +8,6 @@ import workflows4s.runtime.WorkflowInstance
 import workflows4s.runtime.wakeup.KnockerUpper
 import workflows4s.wio.{WCState, WorkflowContext}
 
-import scala.annotation.nowarn
-
-@nowarn("msg=unused value")
-@nowarn("msg=unused local definition")
 object PostgresExample {
 
   object MyWorkflowCtx extends WorkflowContext {
@@ -28,12 +24,8 @@ object PostgresExample {
   val eventCodec: EventCodec[Event]                = ???
   val transactor: Transactor[IO]                   = ???
 
-  PostgresRuntime
-    .default(workflow, initialState, eventCodec, transactor, knockerUpper) // Resource
-    .use(runtime => {
-      val wfInstance: IO[WorkflowInstance[IO, WCState[Ctx]]] = runtime.createInstance(WorkflowId(1L))
-      ???
-    })
+  val runtime: PostgresRuntime[Ctx]                      = PostgresRuntime.default(workflow, InitialState(), eventCodec, transactor, knockerUpper)
+  val wfInstance: IO[WorkflowInstance[IO, WCState[Ctx]]] = runtime.createInstance(WorkflowId(1L))
   // doc_end
 
 }

--- a/workflows4s-example/src/test/scala/workflows4s/example/TestRuntimeAdapter.scala
+++ b/workflows4s-example/src/test/scala/workflows4s/example/TestRuntimeAdapter.scala
@@ -205,13 +205,8 @@ object TestRuntimeAdapter {
         state: WCState[Ctx],
         clock: Clock,
     ): Actor = {
-      import cats.effect.unsafe.implicits.global
       val runtime =
-        PostgresRuntime
-          .default[Ctx, Unit](workflow, state, eventCodec, xa, NoOpKnockerUpper.Agent, clock)
-          .allocated // we shamelessly dont release it and hope its fine enough for tests.
-          .unsafeRunSync()
-          ._1
+        PostgresRuntime.default[Ctx, Unit](workflow, state, eventCodec, xa, NoOpKnockerUpper.Agent, clock)
       Actor(runtime.createInstance(WorkflowId(Random.nextLong())))
     }
 


### PR DESCRIPTION
Drops recent change where runtime required `LiftIO`. Now it gets created for each operation