### PR TITLE
Handle recursive WIO in fork branches

### DIFF
--- a/workflows4s-core/src/main/scala/workflows4s/wio/Interpreter.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/Interpreter.scala
@@ -119,7 +119,7 @@ abstract class Visitor[Ctx <: WorkflowContext, In, Err, Out <: WCState[Ctx]](wio
 
   case class Matching[BranchIn](idx: Int, input: BranchIn, wio: WIO[BranchIn, Err, Out, Ctx])
   def selectMatching(wio: WIO.Fork[Ctx, In, Err, Out], in: In): Option[Matching[?]] = {
-    wio.branches.zipWithIndex.collectFirstSome((branch, idx) => branch.condition(in).map(interm => Matching(idx, interm, branch.wio)))
+    wio.branches.zipWithIndex.collectFirstSome((branch, idx) => branch.condition(in).map(interm => Matching(idx, interm, branch.wio())))
   }
 
   def convertEmbeddingResult2[InnerCtx <: WorkflowContext, InnerOut <: WCState[InnerCtx], O1[_ <: WCState[InnerCtx]] <: WCState[Ctx]](

--- a/workflows4s-core/src/main/scala/workflows4s/wio/WIO.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/WIO.scala
@@ -192,17 +192,17 @@ object WIO {
 
   case class Branch[-In, +Err, +Out <: WCState[Ctx], Ctx <: WorkflowContext, BranchIn](
       condition: In => Option[BranchIn],
-      wio: WIO[BranchIn, Err, Out, Ctx],
+      wio: () => WIO[BranchIn, Err, Out, Ctx],
       name: Option[String],
   )
 
   object Branch {
     def selected[Err, Out <: WCState[Ctx], Ctx <: WorkflowContext, BranchIn](
         branchIn: BranchIn,
-        wio: WIO[BranchIn, Err, Out, Ctx],
+        wio: => WIO[BranchIn, Err, Out, Ctx],
         name: Option[String],
     ): Branch[Any, Err, Out, Ctx, BranchIn] =
-      Branch(_ => Some(branchIn), wio, name)
+      Branch(_ => Some(branchIn), () => wio, name)
   }
 
   case class Executed[Ctx <: WorkflowContext, +Err, +Out <: WCState[Ctx], In](original: WIO[In, ?, ?, Ctx], output: Either[Err, Out], input: In)

--- a/workflows4s-core/src/main/scala/workflows4s/wio/builders/BranchBuilder.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/builders/BranchBuilder.scala
@@ -12,13 +12,13 @@ object BranchBuilder {
 
     case class BranchBuilderStep1[In]() {
 
-      def when[Err, Out <: WCState[Ctx]](cond: In => Boolean)(wio: WIO[In, Err, Out, Ctx]): Step2[In, Err, Out] =
-        Step2(x => Option.when(cond(x))(x), wio, None)
+      def when[Err, Out <: WCState[Ctx]](cond: In => Boolean)(wio: => WIO[In, Err, Out, Ctx]): Step2[In, Err, Out] =
+        Step2(x => Option.when(cond(x))(x), () => wio, None)
 
-      def create[T, Err, Out <: WCState[Ctx]](cond: In => Option[T])(wio: WIO[T, Err, Out, Ctx]): Step2[T, Err, Out] =
-        Step2(cond, wio, None)
+      def create[T, Err, Out <: WCState[Ctx]](cond: In => Option[T])(wio: => WIO[T, Err, Out, Ctx]): Step2[T, Err, Out] =
+        Step2(cond, () => wio, None)
 
-      case class Step2[T, Err, Out <: WCState[Ctx]](cond: In => Option[T], wio: WIO[T, Err, Out, Ctx], name: Option[String]) {
+      case class Step2[T, Err, Out <: WCState[Ctx]](cond: In => Option[T], wio: () => WIO[T, Err, Out, Ctx], name: Option[String]) {
 
         def named(name: String): Step2[T, Err, Out]                   = this.copy(name = name.some)
         def autoNamed()(using n: sourcecode.Name): Step2[T, Err, Out] = named(ModelUtils.prettifyName(n.value))

--- a/workflows4s-core/src/main/scala/workflows4s/wio/builders/ForkBuilder.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/builders/ForkBuilder.scala
@@ -14,9 +14,9 @@ object ForkBuilder {
 
     case class ForkBuilder[-In, +Err, +Out <: WCState[Ctx]](branches: Vector[WIO.Branch[In, Err, Out, Ctx, ?]], name: Option[String]) {
       def onSome[T, Err1 >: Err, Out1 >: Out <: WCState[Ctx], In1 <: In](cond: In1 => Option[T])(
-          wio: WIO[T, Err1, Out1, Ctx],
+          wio: => WIO[T, Err1, Out1, Ctx],
           name: String = null,
-      ): ForkBuilder[In1, Err1, Out1] = addBranch(WIO.Branch(cond, wio, Option(name)))
+      ): ForkBuilder[In1, Err1, Out1] = addBranch(WIO.Branch(cond, () => wio, Option(name)))
 
       // here we can add some APIs for exhaustive handling of Booleans or Eithers.
 

--- a/workflows4s-core/src/main/scala/workflows4s/wio/internal/ExecutionProgressEvaluator.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/internal/ExecutionProgressEvaluator.scala
@@ -77,7 +77,7 @@ object ExecutionProgressEvaluator {
 
     def onFork(wio: WIO.Fork[Ctx, In, Err, Out]): Result                             = {
       WIOExecutionProgress.Fork(
-        wio.branches.map(x => recurse(x.wio, input.flatMap(x.condition), result = None)),
+        wio.branches.map(x => recurse(x.wio(), input.flatMap(x.condition), result = None)),
         WIOMeta.Fork(wio.name, wio.branches.map(x => WIOMeta.Branch(x.name))),
         wio.selected,
       )

--- a/workflows4s-core/src/main/scala/workflows4s/wio/internal/GetStateEvaluator.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/internal/GetStateEvaluator.scala
@@ -66,7 +66,7 @@ object GetStateEvaluator {
       wio.selected match {
         case Some(selectedIdx) =>
           val branch = wio.branches(selectedIdx)
-          recurse(branch.wio, branch.condition(input).get)
+          recurse(branch.wio(), branch.condition(input).get)
         case None              => None
       }
     }

--- a/workflows4s-core/src/main/scala/workflows4s/wio/internal/GetWakeupEvaluator.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/internal/GetWakeupEvaluator.scala
@@ -37,7 +37,7 @@ object GetWakeupEvaluator {
 
     def onAndThen[Out1 <: WCState[Ctx]](wio: WIO.AndThen[Ctx, In, Err, Out1, Out]): Result   = recurse(wio.second).orElse(recurse(wio.first))
     def onHandleErrorWith[ErrIn](wio: WIO.HandleErrorWith[Ctx, In, ErrIn, Out, Err]): Result = recurse(wio.handleError).orElse(recurse(wio.base))
-    def onFork(wio: WIO.Fork[Ctx, In, Err, Out]): Result                                     = wio.selected.flatMap(idx => recurse(wio.branches(idx).wio))
+    def onFork(wio: WIO.Fork[Ctx, In, Err, Out]): Result                                     = wio.selected.flatMap(idx => recurse(wio.branches(idx).wio()))
 
     def onHandleInterruption(wio: WIO.HandleInterruption[Ctx, In, Err, Out]): Result = {
       val fromInterruption = recurse(wio.interruption)

--- a/workflows4s-core/src/main/scala/workflows4s/wio/internal/ProceedingVisitor.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/internal/ProceedingVisitor.scala
@@ -156,7 +156,7 @@ abstract class ProceedingVisitor[Ctx <: WorkflowContext, In, Err, Out <: WCState
       case Some(selectedIdx) =>
         val branch    = wio.branches(selectedIdx)
         val branchOut = branch.condition(input).get
-        recurse(branch.wio, branchOut).map({
+        recurse(branch.wio(), branchOut).map({
           case WFExecution.Complete(wio) => WFExecution.complete(updateSelectedBranch(Matching(selectedIdx, branchOut, wio)), wio.output, input)
           case WFExecution.Partial(wio)  => WFExecution.Partial(updateSelectedBranch(Matching(selectedIdx, branchOut, wio)))
         })

--- a/workflows4s-core/src/test/scala/workflows4s/testing/TestUtils.scala
+++ b/workflows4s-core/src/test/scala/workflows4s/testing/TestUtils.scala
@@ -29,6 +29,14 @@ object TestUtils {
     (clock, instance)
   }
 
+  def createInstance3(wio: WIO.Initial[TestCtx3.Ctx]): (TestClock, InMemorySyncWorkflowInstance[TestCtx3.Ctx]) = {
+    val clock                                               = new TestClock()
+    import cats.effect.unsafe.implicits.global
+    val instance: InMemorySyncWorkflowInstance[TestCtx3.Ctx] =
+      new InMemorySyncRuntime(wio, "initialState", clock, NoOpKnockerUpper.Agent).createInstance(())
+    (clock, instance)
+  }
+
   def pure: (StepId, WIO[TestState, Nothing, TestState, TestCtx2.Ctx])         = {
     import TestCtx2.*
     val stepId = StepId.random

--- a/workflows4s-core/src/test/scala/workflows4s/wio/WIOForkTest.scala
+++ b/workflows4s-core/src/test/scala/workflows4s/wio/WIOForkTest.scala
@@ -3,37 +3,100 @@ package workflows4s.wio
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{EitherValues, OptionValues}
+import workflows4s.mermaid.MermaidRenderer
 import workflows4s.testing.TestUtils
 
 class WIOForkTest extends AnyFreeSpec with Matchers with OptionValues with EitherValues {
 
+  import TestCtx3.*
+
   "WIO.fork" - {
 
-    "should execute parallel elements and combine their results" in {
-      val (step1Id, step1) = TestUtils.pure
-      val (step2Id, step2) = TestUtils.pure
+    "should execute the branch which matches the input" in {
+      val branch1 = WIO.branch[String].when(_ == "one")(WIO.pure("into one").done).done
+      val branch2 = WIO.branch[String].when(_ == "two")(WIO.pure("into two").done).done
 
-      val (parStepId, wf) = createParallel(step1, step2)
+      val wf: WIO.Initial = createFork(branch1, branch2).provideInput("one")
 
-      val (_, instance) = TestUtils.createInstance2(wf.provideInput(TestState.empty))
+      val (_, instance) = TestUtils.createInstance3(wf)
       val resultState   = instance.queryState()
 
-      assert(resultState.executed == List(step1Id, step2Id, parStepId))
+      assert(resultState == "into one")
+    }
+
+    "should handle recursion at execution time" in {
+      val loop = repeatUntil(
+        WIO.pure.makeFrom[String].value(_ + ".").done,
+      )({ value =>
+        if (value.length >= 5) Right(value)
+        else Left(value)
+      })
+
+      val wf: WIO.Initial = loop.provideInput("")
+
+      val (_, instance) = TestUtils.createInstance3(wf)
+      val resultState   = instance.queryState()
+
+      assert(resultState == ".....")
+    }
+
+    "should handle recursion when generating a diagram" in {
+      val loop = repeatUntil(
+        WIO.pure.makeFrom[String].value(_ + ".").done,
+      )({ value =>
+        if (value.length >= 5) Right(value)
+        else Left(value)
+      })
+
+      val wf: WIO.Initial = loop.provideInput("")
+
+      val flowchart = MermaidRenderer.renderWorkflow(wf.toProgress, showTechnical = true)
+      val rendered = flowchart.render
+
+      assert(rendered ==
+        """flowchart TD
+          |node0@{ shape: circle, label: "Start"}
+          |node1["@computation"]
+          |node0 --> node1
+          |""".stripMargin)
     }
   }
 
-  def createParallel[Err](
-      step1: TestCtx2.WIO[TestState, Err, TestState],
-      step2: TestCtx2.WIO[TestState, Err, TestState],
-  ): (StepId, WIO[Any, Err, TestState, TestCtx2.Ctx]) = {
-    val parStepId = StepId.random
-    val wf        = TestCtx2.WIO.parallel
-      .taking[TestState]
-      .withInterimState[TestState](in => in)
-      .withElement(step1, _ ++ _)
-      .withElement(step2, _ ++ _)
-      .producingOutputWith((a, b) => (a ++ b).addExecuted(parStepId))
-    (parStepId, wf.provideInput(TestState.empty))
+  def createFork[Err](
+      branch1: WIO.Branch[String, Err, String],
+      branch2: WIO.Branch[String, Err, String],
+  ): WIO[String, Err, String] =
+    WIO.fork
+      .addBranch(branch1)
+      .addBranch(branch2)
+      .done
+
+  def repeatUntil[BodyIn, Err, BodyOut <: State, LoopOut <: State](
+      body: WIO[BodyIn, Err, BodyOut],
+  )(repeat: BodyOut => Either[BodyIn, LoopOut]): WIO[BodyIn, Err, LoopOut] = {
+    def loop: WIO[BodyIn, Err, LoopOut] = {
+      val condRepeat = WIO
+        .branch[BodyOut]
+        .create(repeat.andThen(_.left.toOption))(loop)
+        .done
+
+      val condExit = WIO
+        .branch[BodyOut]
+        .create(repeat.andThen(_.toOption))(
+          WIO.pure.makeFrom.value((x: LoopOut) => x).done,
+        )
+        .done
+
+      val fork = WIO
+        .fork[BodyOut]
+        .addBranch(condRepeat)
+        .addBranch(condExit)
+        .done
+
+      body.andThen(fork)
+    }
+
+    loop
   }
 
 }

--- a/workflows4s-core/src/test/scala/workflows4s/wio/WIOForkTest.scala
+++ b/workflows4s-core/src/test/scala/workflows4s/wio/WIOForkTest.scala
@@ -1,0 +1,39 @@
+package workflows4s.wio
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{EitherValues, OptionValues}
+import workflows4s.testing.TestUtils
+
+class WIOForkTest extends AnyFreeSpec with Matchers with OptionValues with EitherValues {
+
+  "WIO.fork" - {
+
+    "should execute parallel elements and combine their results" in {
+      val (step1Id, step1) = TestUtils.pure
+      val (step2Id, step2) = TestUtils.pure
+
+      val (parStepId, wf) = createParallel(step1, step2)
+
+      val (_, instance) = TestUtils.createInstance2(wf.provideInput(TestState.empty))
+      val resultState   = instance.queryState()
+
+      assert(resultState.executed == List(step1Id, step2Id, parStepId))
+    }
+  }
+
+  def createParallel[Err](
+      step1: TestCtx2.WIO[TestState, Err, TestState],
+      step2: TestCtx2.WIO[TestState, Err, TestState],
+  ): (StepId, WIO[Any, Err, TestState, TestCtx2.Ctx]) = {
+    val parStepId = StepId.random
+    val wf        = TestCtx2.WIO.parallel
+      .taking[TestState]
+      .withInterimState[TestState](in => in)
+      .withElement(step1, _ ++ _)
+      .withElement(step2, _ ++ _)
+      .producingOutputWith((a, b) => (a ++ b).addExecuted(parStepId))
+    (parStepId, wf.provideInput(TestState.empty))
+  }
+
+}

--- a/workflows4s-core/src/test/scala/workflows4s/wio/common.scala
+++ b/workflows4s-core/src/test/scala/workflows4s/wio/common.scala
@@ -35,3 +35,9 @@ object TestCtx2 extends WorkflowContext {
   case class SimpleEvent(value: String) extends Event
   type State = TestState
 }
+
+object TestCtx3 extends WorkflowContext {
+  trait Event
+  case class SimpleEvent(value: String) extends Event
+  type State = String
+}


### PR DESCRIPTION
Makes the branches of a `WIO.fork` lazy to enable recusion.

Example:
```scala
def repeatUntil[BodyIn, Err, BodyOut <: State, LoopOut <: State](
    body: WIO[BodyIn, Err, BodyOut]
)(repeat: BodyOut => Either[BodyIn, LoopOut]): WIO[BodyIn, Err, LoopOut] = {
  def loop: WIO[BodyIn, Err, LoopOut] = {
    val condRepeat = WIO
      .branch[BodyOut]
      .create(repeat.andThen(_.left.toOption))(loop)
      .done

    val condExit = WIO
      .branch[BodyOut]
      .create(repeat.andThen(_.toOption))(
        WIO.pure.makeFrom.value((x: LoopOut) => x).done
      )
      .done

    val fork = WIO
      .fork[BodyOut]
      .addBranch(condRepeat)
      .addBranch(condExit)
      .done

    body.andThen(fork)
  }

  loop
}
```