### PR TITLE
Add the ability to branch into value or error in WIO.pure.makeFrom

### DIFF
--- a/workflows4s-core/src/main/scala/workflows4s/wio/builders/PureBuilder.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/builders/PureBuilder.scala
@@ -20,14 +20,14 @@ object PureBuilder {
 
       case class MakeStep[In]() {
         def apply[Err, Out <: WCState[Ctx]](f: In => Either[Err, Out])(using em: ErrorMeta[Err]): Step2[In, Err, Out] = Step2(f, None)
-        
+
         def value[O <: WCState[Ctx]](f: In => O): Step2[In, Nothing, O] = Step2[In, Nothing, O](f.andThen(_.asRight), None)
-        
+
         def error[Err](f: In => Err)(using em: ErrorMeta[Err]): Step2[In, Err, Nothing] = Step2[In, Err, Nothing](f.andThen(_.asLeft), None)
 
         def errorOpt[Err, Out >: In <: WCState[Ctx]](f: In => Option[Err])(using em: ErrorMeta[Err]): Step2[In, Err, Out] =
           Step2[In, Err, Out](s => f(s).map(Left(_)).getOrElse(Right(s: In)), None)
-        
+
       }
 
       case class Step2[In, Err, Out <: WCState[Ctx]](f: In => Either[Err, Out], name: Option[String])(using em: ErrorMeta[Err]) {

--- a/workflows4s-core/src/main/scala/workflows4s/wio/builders/PureBuilder.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/builders/PureBuilder.scala
@@ -19,13 +19,15 @@ object PureBuilder {
       def makeFrom[In]: MakeStep[In] = MakeStep[In]()
 
       case class MakeStep[In]() {
+        def apply[Err, Out <: WCState[Ctx]](f: In => Either[Err, Out])(using em: ErrorMeta[Err]): Step2[In, Err, Out] = Step2(f, None)
+        
         def value[O <: WCState[Ctx]](f: In => O): Step2[In, Nothing, O] = Step2[In, Nothing, O](f.andThen(_.asRight), None)
-
+        
         def error[Err](f: In => Err)(using em: ErrorMeta[Err]): Step2[In, Err, Nothing] = Step2[In, Err, Nothing](f.andThen(_.asLeft), None)
 
         def errorOpt[Err, Out >: In <: WCState[Ctx]](f: In => Option[Err])(using em: ErrorMeta[Err]): Step2[In, Err, Out] =
           Step2[In, Err, Out](s => f(s).map(Left(_)).getOrElse(Right(s: In)), None)
-
+        
       }
 
       case class Step2[In, Err, Out <: WCState[Ctx]](f: In => Either[Err, Out], name: Option[String])(using em: ErrorMeta[Err]) {


### PR DESCRIPTION
Useful in conjunction with #76 to gracefully recover from non-fatal errors in the loop