### PR TITLE
Make in-memory runtime store active instances

### DIFF
--- a/workflows4s-core/src/main/scala/workflows4s/runtime/InMemoryRuntime.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/runtime/InMemoryRuntime.scala
@@ -11,7 +11,7 @@ import java.time.Clock
   *
   * IT'S NOT A GENERAL-PURPOSE RUNTIME
   */
-class InMemoryRuntime[Ctx <: WorkflowContext, WorkflowId](
+class InMemoryRuntime[Ctx <: WorkflowContext, WorkflowId] private (
     workflow: Initial[Ctx],
     initialState: WCState[Ctx],
     clock: Clock,

--- a/workflows4s-core/src/main/scala/workflows4s/runtime/InMemoryRuntime.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/runtime/InMemoryRuntime.scala
@@ -45,11 +45,12 @@ object InMemoryRuntime {
       workflow: Initial[Ctx],
       initialState: WCState[Ctx],
       knockerUpper: KnockerUpper.Agent[Id],
+      clock: Clock = Clock.systemUTC(),
   ): IO[InMemoryRuntime[Ctx, Id]] = {
     Ref
       .of[IO, Map[Id, InMemoryWorkflowInstance[Ctx]]](Map.empty)
       .map({ instances =>
-        new InMemoryRuntime[Ctx, Id](workflow, initialState, Clock.systemUTC(), knockerUpper, instances)
+        new InMemoryRuntime[Ctx, Id](workflow, initialState, clock, knockerUpper, instances)
       })
   }
 

--- a/workflows4s-core/src/main/scala/workflows4s/runtime/InMemorySyncRuntime.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/runtime/InMemorySyncRuntime.scala
@@ -15,22 +15,24 @@ class InMemorySyncRuntime[Ctx <: WorkflowContext, WorkflowId](
     knockerUpperAgent: KnockerUpper.Agent[WorkflowId],
 )(using IORuntime)
     extends WorkflowRuntime[Id, Ctx, WorkflowId] {
+  val instances = new java.util.concurrent.ConcurrentHashMap[WorkflowId, InMemorySyncWorkflowInstance[Ctx]]()
 
   override def createInstance(id: WorkflowId): InMemorySyncWorkflowInstance[Ctx] = {
-    val atomicRef                     = new java.util.concurrent.atomic.AtomicReference[InMemorySyncWorkflowInstance[Ctx]](null)
-    val activeWf: ActiveWorkflow[Ctx] = ActiveWorkflow(workflow, initialState)
-    val instance                      = new InMemorySyncWorkflowInstance[Ctx](activeWf, clock, knockerUpperAgent.curried(id))
-    atomicRef.set(instance)
-    instance
+    instances.computeIfAbsent(
+      id,
+      { _ =>
+        val activeWf: ActiveWorkflow[Ctx] = ActiveWorkflow(workflow, initialState)
+        new InMemorySyncWorkflowInstance[Ctx](activeWf, clock, knockerUpperAgent.curried(id))
+      },
+    )
   }
-
 }
 
 object InMemorySyncRuntime {
-  def default[Ctx <: WorkflowContext](
+  def default[Ctx <: WorkflowContext, Id](
       workflow: Initial[Ctx],
       initialState: WCState[Ctx],
-      knockerUpperAgent: KnockerUpper.Agent[Unit] = NoOpKnockerUpper.Agent,
-  ): InMemorySyncRuntime[Ctx, Unit] =
-    new InMemorySyncRuntime[Ctx, Unit](workflow, initialState, Clock.systemUTC(), knockerUpperAgent)(using IORuntime.global)
+      knockerUpperAgent: KnockerUpper.Agent[Id] = NoOpKnockerUpper.Agent,
+  ): InMemorySyncRuntime[Ctx, Id] =
+    new InMemorySyncRuntime[Ctx, Id](workflow, initialState, Clock.systemUTC(), knockerUpperAgent)(using IORuntime.global)
 }

--- a/workflows4s-core/src/main/scala/workflows4s/runtime/InMemorySyncRuntime.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/runtime/InMemorySyncRuntime.scala
@@ -33,6 +33,7 @@ object InMemorySyncRuntime {
       workflow: Initial[Ctx],
       initialState: WCState[Ctx],
       knockerUpperAgent: KnockerUpper.Agent[Id] = NoOpKnockerUpper.Agent,
+      clock: Clock = Clock.systemUTC(),
   ): InMemorySyncRuntime[Ctx, Id] =
-    new InMemorySyncRuntime[Ctx, Id](workflow, initialState, Clock.systemUTC(), knockerUpperAgent)(using IORuntime.global)
+    new InMemorySyncRuntime[Ctx, Id](workflow, initialState, clock, knockerUpperAgent)(using IORuntime.global)
 }

--- a/workflows4s-core/src/test/scala/workflows4s/runtime/InMemoryRuntimeTest.scala
+++ b/workflows4s-core/src/test/scala/workflows4s/runtime/InMemoryRuntimeTest.scala
@@ -1,0 +1,30 @@
+package workflows4s.runtime
+
+import org.scalatest.freespec.AnyFreeSpec
+import workflows4s.runtime.wakeup.NoOpKnockerUpper
+import cats.effect.unsafe.implicits.global
+
+class InMemoryRuntimeTest extends AnyFreeSpec {
+
+  import workflows4s.wio.TestCtx.*
+
+  "InMemoryRuntime" - {
+
+    "should return the same workflow instance for the same id" in {
+      val workflow: WIO.Initial = WIO.pure("myValue").done
+      val runtime               = InMemoryRuntime
+        .default[Ctx, String](
+          workflow = workflow,
+          initialState = "initialState",
+          knockerUpper = NoOpKnockerUpper.Agent,
+        )
+        .unsafeRunSync()
+
+      val instance1 = runtime.createInstance("id1").unsafeRunSync()
+      val instance2 = runtime.createInstance("id1").unsafeRunSync()
+      assert(instance1 == instance2)
+    }
+
+  }
+
+}

--- a/workflows4s-core/src/test/scala/workflows4s/runtime/InMemorySyncRuntimeTest.scala
+++ b/workflows4s-core/src/test/scala/workflows4s/runtime/InMemorySyncRuntimeTest.scala
@@ -1,0 +1,28 @@
+package workflows4s.runtime
+
+import org.scalatest.freespec.AnyFreeSpec
+import workflows4s.runtime.wakeup.NoOpKnockerUpper
+
+class InMemorySyncRuntimeTest extends AnyFreeSpec {
+
+  import workflows4s.wio.TestCtx.*
+
+  "InMemorySyncRuntime" - {
+
+    "should return the same workflow instance for the same id" in {
+      val workflow: WIO.Initial = WIO.pure("myValue").done
+      val runtime = InMemorySyncRuntime
+        .default[Ctx, String](
+          workflow = workflow,
+          initialState = "initialState",
+          knockerUpperAgent = NoOpKnockerUpper.Agent,
+        )
+
+      val instance1 = runtime.createInstance("id1")
+      val instance2 = runtime.createInstance("id1")
+      assert(instance1 == instance2)
+    }
+
+  }
+
+}

--- a/workflows4s-core/src/test/scala/workflows4s/runtime/InMemorySyncRuntimeTest.scala
+++ b/workflows4s-core/src/test/scala/workflows4s/runtime/InMemorySyncRuntimeTest.scala
@@ -11,7 +11,7 @@ class InMemorySyncRuntimeTest extends AnyFreeSpec {
 
     "should return the same workflow instance for the same id" in {
       val workflow: WIO.Initial = WIO.pure("myValue").done
-      val runtime = InMemorySyncRuntime
+      val runtime               = InMemorySyncRuntime
         .default[Ctx, String](
           workflow = workflow,
           initialState = "initialState",

--- a/workflows4s-example/src/main/scala/workflows4s/example/docs/InMemoryRuntimeExample.scala
+++ b/workflows4s-example/src/main/scala/workflows4s/example/docs/InMemoryRuntimeExample.scala
@@ -4,6 +4,7 @@ import cats.effect.IO
 import workflows4s.runtime.wakeup.KnockerUpper
 import workflows4s.runtime.{InMemoryRuntime, InMemorySyncRuntime, InMemorySyncWorkflowInstance, InMemoryWorkflowInstance}
 import workflows4s.wio.WorkflowContext
+import cats.effect.unsafe.implicits.global
 
 object InMemoryRuntimeExample {
 
@@ -19,7 +20,9 @@ object InMemoryRuntimeExample {
     import MyWorkflowCtx.*
     val workflow: WIO.Initial                               = ???
     val knockerUpperAgent: KnockerUpper.Agent[MyWorkflowId] = ???
-    val runtime: InMemoryRuntime[Ctx, MyWorkflowId]         = InMemoryRuntime.default(workflow, InitialState(), knockerUpperAgent)
+    val runtime: InMemoryRuntime[Ctx, MyWorkflowId]         = InMemoryRuntime
+      .default(workflow, InitialState(), knockerUpperAgent)
+      .unsafeRunSync()
     val wfInstance: IO[InMemoryWorkflowInstance[Ctx]]       = runtime.createInstance(??? : MyWorkflowId)
     // async_doc_end
   }

--- a/workflows4s-example/src/main/scala/workflows4s/example/docs/pullrequest/MinimalWorkflow.scala
+++ b/workflows4s-example/src/main/scala/workflows4s/example/docs/pullrequest/MinimalWorkflow.scala
@@ -19,8 +19,8 @@ object MinimalWorkflow {
     println(MermaidRenderer.renderWorkflow(workflow.toProgress).toViewUrl)
     // https://mermaid.live/edit#pako:flowchart+TD%0Anode0%40%7B+shape%3A+circle%2C+label%3A+%22Start%22%7D%0Anode1%5B%22Hello%22%5D%0Anode0+--%3E+node1%0Anode2%5B%22World%22%5D%0Anode1+--%3E+node2%0A
 
-    val runtime    = InMemorySyncRuntime.default[Context.Ctx](workflow, "")
-    val wfInstance = runtime.createInstance(())
+    val runtime    = InMemorySyncRuntime.default[Context.Ctx, String](workflow, "")
+    val wfInstance = runtime.createInstance("id")
 
     wfInstance.wakeup()
 

--- a/workflows4s-example/src/main/scala/workflows4s/example/docs/pullrequest/PullRequestWorkflow.scala
+++ b/workflows4s-example/src/main/scala/workflows4s/example/docs/pullrequest/PullRequestWorkflow.scala
@@ -117,8 +117,8 @@ object PullRequestWorkflow {
     // end_render
 
     // start_execution
-    val runtime    = InMemorySyncRuntime.default[Context.Ctx](workflow, PRState.Empty)
-    val wfInstance = runtime.createInstance(())
+    val runtime    = InMemorySyncRuntime.default[Context.Ctx, String](workflow, PRState.Empty)
+    val wfInstance = runtime.createInstance("id")
 
     wfInstance.deliverSignal(Signals.createPR, Signals.CreateRequest("some-sha"))
     println(wfInstance.queryState())
@@ -130,7 +130,7 @@ object PullRequestWorkflow {
     // end_execution
 
     // start_recovery
-    val recoveredInstance = runtime.createInstance(())
+    val recoveredInstance = runtime.createInstance("id")
     recoveredInstance.recover(wfInstance.getEvents)
     assert(wfInstance.queryState() == recoveredInstance.queryState())
     // end_recovery

--- a/workflows4s-example/src/test/scala/workflows4s/example/TestRuntimeAdapter.scala
+++ b/workflows4s-example/src/test/scala/workflows4s/example/TestRuntimeAdapter.scala
@@ -102,7 +102,7 @@ object TestRuntimeAdapter {
         with EventIntrospection[WCEvent[Ctx]] {
       import cats.effect.unsafe.implicits.global
       val base = {
-        val runtime = new InMemoryRuntime[Ctx, Unit](workflow, state, clock, NoOpKnockerUpper.Agent)
+        val runtime = InMemoryRuntime.default[Ctx, Unit](workflow, state, NoOpKnockerUpper.Agent).unsafeRunSync()
         val inst    = runtime.createInstance(()).unsafeRunSync()
         inst.recover(events).unsafeRunSync()
         inst

--- a/workflows4s-example/src/test/scala/workflows4s/example/TestRuntimeAdapter.scala
+++ b/workflows4s-example/src/test/scala/workflows4s/example/TestRuntimeAdapter.scala
@@ -102,7 +102,7 @@ object TestRuntimeAdapter {
         with EventIntrospection[WCEvent[Ctx]] {
       import cats.effect.unsafe.implicits.global
       val base = {
-        val runtime = InMemoryRuntime.default[Ctx, Unit](workflow, state, NoOpKnockerUpper.Agent).unsafeRunSync()
+        val runtime = InMemoryRuntime.default[Ctx, Unit](workflow, state, NoOpKnockerUpper.Agent, clock).unsafeRunSync()
         val inst    = runtime.createInstance(()).unsafeRunSync()
         inst.recover(events).unsafeRunSync()
         inst


### PR DESCRIPTION
If the runtime is behind a facade, the basic `InMemoryRuntime` creates a new instance of the workflow on every call which makes testing basically impossible.