### PR TITLE
Dont lie about initial state in ActiveWorkflow

### DIFF
--- a/workflows4s-core/src/main/scala/workflows4s/wio/Interpreter.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/Interpreter.scala
@@ -19,7 +19,7 @@ object Interpreter {
 
   object EventResponse {
     case class Ok[Ctx <: WorkflowContext](newFlow: WIO.Initial[Ctx]) extends EventResponse[Ctx]
-    case class UnexpectedEvent[Ctx <: WorkflowContext]()                extends EventResponse[Ctx]
+    case class UnexpectedEvent[Ctx <: WorkflowContext]()             extends EventResponse[Ctx]
   }
 
   sealed trait ProceedResponse[Ctx <: WorkflowContext] {
@@ -146,7 +146,7 @@ sealed trait WFExecution[C <: WorkflowContext, -I, +E, +O <: WCState[C]] {
 }
 
 object WFExecution {
-  
+
   case class Complete[C <: WorkflowContext, E, O <: WCState[C], I](wio: WIO.Executed[C, E, O, I]) extends WFExecution[C, I, E, O]
 
   case class Partial[C <: WorkflowContext, I, E, O <: WCState[C]](wio: WIO[I, E, O, C]) extends WFExecution[C, I, E, O]

--- a/workflows4s-core/src/main/scala/workflows4s/wio/Interpreter.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/Interpreter.scala
@@ -9,7 +9,7 @@ import scala.annotation.nowarn
 object Interpreter {
 
   sealed trait EventResponse[Ctx <: WorkflowContext] {
-    def newWorkflow: Option[ActiveWorkflow[Ctx]] = this match {
+    def newWorkflow: Option[WIO.Initial[Ctx]] = this match {
       case EventResponse.Ok(newFlow)       => newFlow.some
       // TODO event is silently ignored here and runtimes have to log it.
       //   Would be good to commonize this behavior
@@ -18,13 +18,8 @@ object Interpreter {
   }
 
   object EventResponse {
-    case class Ok[Ctx <: WorkflowContext](newFlow: ActiveWorkflow[Ctx]) extends EventResponse[Ctx]
+    case class Ok[Ctx <: WorkflowContext](newFlow: WIO.Initial[Ctx]) extends EventResponse[Ctx]
     case class UnexpectedEvent[Ctx <: WorkflowContext]()                extends EventResponse[Ctx]
-
-    def fromOption[Ctx <: WorkflowContext](o: Option[ActiveWorkflow[Ctx]]): EventResponse[Ctx] = o match {
-      case Some(value) => Ok(value)
-      case None        => UnexpectedEvent()
-    }
   }
 
   sealed trait ProceedResponse[Ctx <: WorkflowContext] {
@@ -151,12 +146,7 @@ sealed trait WFExecution[C <: WorkflowContext, -I, +E, +O <: WCState[C]] {
 }
 
 object WFExecution {
-
-  extension [C <: WorkflowContext](wfe: WFExecution[C, Any, Nothing, WCState[C]]) {
-    def toActiveWorkflow(initialState: WCState[C]): ActiveWorkflow[C] = {
-      ActiveWorkflow(wfe.wio, initialState)
-    }
-  }
+  
   case class Complete[C <: WorkflowContext, E, O <: WCState[C], I](wio: WIO.Executed[C, E, O, I]) extends WFExecution[C, I, E, O]
 
   case class Partial[C <: WorkflowContext, I, E, O <: WCState[C]](wio: WIO[I, E, O, C]) extends WFExecution[C, I, E, O]

--- a/workflows4s-core/src/main/scala/workflows4s/wio/WIO.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/WIO.scala
@@ -1,10 +1,11 @@
 package workflows4s.wio
 
 import cats.effect.IO
+import cats.implicits.catsSyntaxOptionId
 import workflows4s.wio.WIO.HandleInterruption.InterruptionType
 import workflows4s.wio.WIO.Timer.DurationSource
 import workflows4s.wio.builders.AllBuilders
-import workflows4s.wio.internal.{EventHandler, SignalHandler, WorkflowEmbedding}
+import workflows4s.wio.internal.{EventHandler, GetStateEvaluator, SignalHandler, WorkflowEmbedding}
 
 import java.time.{Duration, Instant}
 import scala.language.implicitConversions
@@ -216,7 +217,12 @@ object WIO {
   }
 
   case class Executed[Ctx <: WorkflowContext, +Err, +Out <: WCState[Ctx], In](original: WIO[In, ?, ?, Ctx], output: Either[Err, Out], input: In)
-      extends WIO[Any, Err, Out, Ctx]
+      extends WIO[Any, Err, Out, Ctx] {
+    def lastState(prevState: WCState[Ctx]): Option[WCState[Ctx]] = output match {
+      case Left(_) => GetStateEvaluator.extractLastState(original, input, prevState)
+      case Right(value) => value.some
+    }
+  }
 
   case class Discarded[Ctx <: WorkflowContext, In](original: WIO[In, ?, ?, Ctx], input: In) extends WIO[Any, Nothing, Nothing, Ctx]
 

--- a/workflows4s-core/src/main/scala/workflows4s/wio/WIO.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/WIO.scala
@@ -219,7 +219,7 @@ object WIO {
   case class Executed[Ctx <: WorkflowContext, +Err, +Out <: WCState[Ctx], In](original: WIO[In, ?, ?, Ctx], output: Either[Err, Out], input: In)
       extends WIO[Any, Err, Out, Ctx] {
     def lastState(prevState: WCState[Ctx]): Option[WCState[Ctx]] = output match {
-      case Left(_) => GetStateEvaluator.extractLastState(original, input, prevState)
+      case Left(_)      => GetStateEvaluator.extractLastState(original, input, prevState)
       case Right(value) => value.some
     }
   }

--- a/workflows4s-core/src/main/scala/workflows4s/wio/internal/EventEvaluator.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/internal/EventEvaluator.scala
@@ -13,8 +13,7 @@ object EventEvaluator {
   ): EventResponse[Ctx] = {
     val visitor: EventVisitor[Ctx, Any, Nothing, WCState[Ctx]] = new EventVisitor(wio, event, state, state)
     visitor.run
-      .map(wf => wf.toActiveWorkflow(state))
-      .map(EventResponse.Ok(_))
+      .map(execution => EventResponse.Ok(execution.wio))
       .getOrElse(EventResponse.UnexpectedEvent())
   }
 

--- a/workflows4s-core/src/main/scala/workflows4s/wio/internal/GetStateEvaluator.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/internal/GetStateEvaluator.scala
@@ -23,7 +23,7 @@ object GetStateEvaluator {
 
     def onExecuted[In1](wio: WIO.Executed[Ctx, Err, Out, In1]): Result = wio.output match {
       // this is potentitally suboptimal. We could cache the state at the moment of emitting the error within Executed
-      case Left(value) => recurse(wio.original, wio.input)
+      case Left(value)  => recurse(wio.original, wio.input)
       case Right(value) => value.some
     }
 

--- a/workflows4s-core/src/main/scala/workflows4s/wio/internal/ProceedEvaluator.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/internal/ProceedEvaluator.scala
@@ -15,10 +15,10 @@ object ProceedEvaluator {
       now: Instant,
   ): Response[Ctx] = {
     val visitor: ProceedVisitor[Ctx, Any, Nothing, WCState[Ctx]] = new ProceedVisitor(wio, state, state, now)
-    Response(visitor.run.map(_.toActiveWorkflow(state)))
+    Response(visitor.run.map(_.wio))
   }
 
-  case class Response[Ctx <: WorkflowContext](newFlow: Option[ActiveWorkflow[Ctx]])
+  case class Response[Ctx <: WorkflowContext](newFlow: Option[WIO.Initial[Ctx]])
 
   private class ProceedVisitor[Ctx <: WorkflowContext, In, Err, Out <: WCState[Ctx]](
       wio: WIO[In, Err, Out, Ctx],

--- a/workflows4s-core/src/test/scala/workflows4s/testing/TestUtils.scala
+++ b/workflows4s-core/src/test/scala/workflows4s/testing/TestUtils.scala
@@ -12,7 +12,7 @@ import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.util.Random
 
 object TestUtils {
-  
+
   type Error = String
 
   def createInstance(wio: WIO.Initial[TestCtx.Ctx]): (TestClock, InMemorySyncWorkflowInstance[TestCtx.Ctx]) = {
@@ -38,7 +38,7 @@ object TestUtils {
     (clock, instance)
   }
 
-  def pure: (StepId, WIO[TestState, Nothing, TestState, TestCtx2.Ctx])         = {
+  def pure: (StepId, WIO[TestState, Nothing, TestState, TestCtx2.Ctx])        = {
     import TestCtx2.*
     val stepId = StepId.random
     (stepId, WIO.pure.makeFrom[TestState].value(_.addExecuted(stepId)).done)
@@ -83,7 +83,7 @@ object TestUtils {
     val signalDef = SignalDef[Int, Int](id = UUID.randomUUID().toString)
     case class SignalErrored(req: Int, error: String) extends TestCtx2.Event
     val error = s"error-${UUID.randomUUID()}"
-    val wio    = WIO
+    val wio   = WIO
       .handleSignal(signalDef)
       .using[TestState]
       .purely((_, req) => SignalErrored(req, error))

--- a/workflows4s-core/src/test/scala/workflows4s/testing/TestUtils.scala
+++ b/workflows4s-core/src/test/scala/workflows4s/testing/TestUtils.scala
@@ -12,6 +12,8 @@ import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.util.Random
 
 object TestUtils {
+  
+  type Error = String
 
   def createInstance(wio: WIO.Initial[TestCtx.Ctx]): (TestClock, InMemorySyncWorkflowInstance[TestCtx.Ctx]) = {
     val clock                                               = new TestClock()
@@ -41,12 +43,12 @@ object TestUtils {
     val stepId = StepId.random
     (stepId, WIO.pure.makeFrom[TestState].value(_.addExecuted(stepId)).done)
   }
-  def error: (String, WIO[Any, String, Nothing, TestCtx2.Ctx])                 = {
+  def error: (Error, WIO[Any, String, Nothing, TestCtx2.Ctx])                 = {
     import TestCtx2.*
     val error = s"error-${UUID.randomUUID()}"
     (error, WIO.pure.error(error).done)
   }
-  def errorIO: (String, WIO[Any, String, Nothing, TestCtx2.Ctx])               = {
+  def errorIO: (Error, WIO[Any, String, Nothing, TestCtx2.Ctx])               = {
     import TestCtx2.*
     val error = s"error-${UUID.randomUUID()}"
     case class RunIOErrored(error: String) extends TestCtx2.Event
@@ -56,7 +58,7 @@ object TestUtils {
       .done
     (error, wio)
   }
-  def errorHandler: WIO[(TestState, String), Nothing, TestState, TestCtx2.Ctx] = {
+  def errorHandler: WIO[(TestState, Error), Nothing, TestState, TestCtx2.Ctx] = {
     import TestCtx2.*
     WIO.pure.makeFrom[(TestState, String)].value((st, err) => st.addError(err)).done
   }
@@ -74,6 +76,21 @@ object TestUtils {
       .produceResponse((_, evt) => evt.req)
       .done
     (signalDef, stepId, wio)
+  }
+
+  def signalError: (SignalDef[Int, Int], Error, WIO.IHandleSignal[TestState, Error, TestState, TestCtx2.Ctx]) = {
+    import TestCtx2.*
+    val signalDef = SignalDef[Int, Int](id = UUID.randomUUID().toString)
+    case class SignalErrored(req: Int, error: String) extends TestCtx2.Event
+    val error = s"error-${UUID.randomUUID()}"
+    val wio    = WIO
+      .handleSignal(signalDef)
+      .using[TestState]
+      .purely((_, req) => SignalErrored(req, error))
+      .handleEventWithError((_, evt) => Left(evt.error))
+      .produceResponse((_, evt) => evt.req)
+      .done
+    (signalDef, error, wio)
   }
 
   def timer(secs: Int = Random.nextInt(10) + 1): (FiniteDuration, WIO[TestState, Nothing, TestState, TestCtx2.Ctx]) = {

--- a/workflows4s-core/src/test/scala/workflows4s/wio/WIOHandleErrorTest.scala
+++ b/workflows4s-core/src/test/scala/workflows4s/wio/WIOHandleErrorTest.scala
@@ -1,6 +1,5 @@
 package workflows4s.wio
 
-import cats.effect.IO
 import org.scalatest.EitherValues
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
@@ -8,58 +7,49 @@ import workflows4s.testing.TestUtils
 
 class WIOHandleErrorTest extends AnyFreeSpec with Matchers with EitherValues {
 
-  import TestCtx.*
-
   case class MyError(value: Int)
 
   "WIO.HandleError" - {
 
     "from pure" in {
-      val base    = WIO.pure("someState").done >>> WIO.pure.error(MyError(1)).done
-      val handler = WIO.pure.makeFrom[(String, MyError)].value((state, error) => s"handlerResult($state, $error)").done
-      val wio     = base.handleErrorWith(handler)
-      val (_, wf) = TestUtils.createInstance(wio)
+      val (step1Id, step1) = TestUtils.pure
+      val (error, step2)   = TestUtils.error
+      val handler          = TestUtils.errorHandler
 
-      assert(wf.queryState() === "handlerResult(someState, MyError(1))")
+      val wio     = (step1 >>> step2).handleErrorWith(handler)
+      val (_, wf) = TestUtils.createInstance2(wio)
+
+      assert(wf.queryState() === TestState(executed = List(step1Id), errors = List(error)))
     }
 
     "from proceed" in {
-      val base    = WIO.pure("someState").done >>> WIO.runIO[Any](in => IO(s"baseEvent($in)")).handleEventWithError((_, _) => Left(MyError(1))).done
-      val handler = WIO.runIO[(String, MyError)](in => IO(s"handlerEvent($in)")).handleEvent((in, event) => s"handlerOut($in, $event)").done
-      val wio     = base.handleErrorWith(handler)
-      val (_, wf) = TestUtils.createInstance(wio)
+      val (step1Id, step1) = TestUtils.runIO
+      val (error, step2)   = TestUtils.error
+      val handler          = TestUtils.errorHandler
+
+      val wio     = (step1 >>> step2).handleErrorWith(handler)
+      val (_, wf) = TestUtils.createInstance2(wio)
 
       wf.wakeup()
-      assert(wf.queryState() === "handlerOut((someState,MyError(1)), SimpleEvent(handlerEvent((someState,MyError(1)))))")
+      assert(wf.queryState() === TestState(executed = List(step1Id), errors = List(error)))
     }
 
     "from signal" in {
-      val signal1 = SignalDef[Int, String]()
-      val signal2 = SignalDef[Int, String]()
-      val base    = WIO.pure("someState").done >>> WIO
-        .handleSignal(signal1)
-        .using[Any]
-        .withSideEffects((in, req) => IO(s"baseEvent($in, $req)"))
-        .handleEventWithError((_, _) => Left(MyError(1)))
-        .produceResponse((in, req) => s"baseResponse($in, $req)")
-        .done >>> WIO.pure("otherState").done
-      val handler = WIO
-        .handleSignal(signal2)
-        .using[Any]
-        .withSideEffects((in, req) => IO(s"handlerEvent($in, $req)"))
-        .handleEvent((in, event) => s"handlerOutput($in, $event)")
-        .produceResponse((in, req) => s"handlerResponse($in, $req)")
-        .done
-      val wio     = base.handleErrorWith(handler)
-      val (_, wf) = TestUtils.createInstance(wio)
+      val (signal1, error, step1)   = TestUtils.signalError
+      val (signal2, step2Id, step2) = TestUtils.signal
+      val (_, step3)                = TestUtils.pure
+      val base                      = step1 >>> step3
+      val handler                   = step2.transformInput[(TestState, String)]((st, err) => st.addError(err))
+      val wio                       = base.handleErrorWith(handler)
+      val (_, wf)                   = TestUtils.createInstance2(wio)
 
       val response = wf.deliverSignal(signal1, 43).value
-      assert(response === "baseResponse(someState, SimpleEvent(baseEvent(someState, 43)))")
-      assert(wf.queryState() === "someState")
+      assert(response === 43)
+      assert(wf.queryState() === TestState.empty)
 
       val response2 = wf.deliverSignal(signal2, 44).value
-      assert(response2 === "handlerResponse((someState,MyError(1)), SimpleEvent(handlerEvent((someState,MyError(1)), 44)))")
-      assert(wf.queryState() === "handlerOutput((someState,MyError(1)), SimpleEvent(handlerEvent((someState,MyError(1)), 44)))")
+      assert(response2 === 44)
+      assert(wf.queryState() === TestState(executed = List(step2Id), errors = List(error)))
     }
 
   }


### PR DESCRIPTION
`ActiveWorkflow` has `initialState` field, which was unnecessarily updated. Then some of the evaluators relied on that fact. Now it should be cleaner, `initialState` is never updated. 