### PR TITLE
Fix Pekko Withdrawal Example:  knockerUpper init and json encoder

### DIFF
--- a/workflows4s-example/src/main/scala/workflows4s/example/pekko/HttpRoutes.scala
+++ b/workflows4s-example/src/main/scala/workflows4s/example/pekko/HttpRoutes.scala
@@ -1,9 +1,7 @@
 package workflows4s.example.pekko
 
 import cats.effect.unsafe.IORuntime
-import cats.implicits.toContravariantOps
 import com.github.pjfanning.pekkohttpcirce.FailFastCirceSupport
-import io.circe.generic.semiauto.deriveEncoder
 import io.circe.syntax.EncoderOps
 import io.circe.{Encoder, Json}
 import org.apache.pekko.http.scaladsl.server.Directives.*
@@ -12,16 +10,35 @@ import workflows4s.example.withdrawal.WithdrawalData
 import workflows4s.example.withdrawal.WithdrawalService.{Fee, Iban}
 import workflows4s.example.withdrawal.WithdrawalSignal.CreateWithdrawal
 import workflows4s.example.withdrawal.checks.{CheckResult, ChecksInput, ChecksState}
+import io.circe.generic.auto.*
 
 class HttpRoutes(service: WithdrawalWorkflowService)(using ioRuntime: IORuntime) extends FailFastCirceSupport {
   given checksInput: Encoder[ChecksInput]                             = Encoder.instance(_.checks.keys.map(_.value).asJson)
   given checksResult: Encoder[CheckResult]                            = Encoder.instance(_ => Json.Null)
   given checksResultFinished: Encoder[CheckResult.Finished]           = Encoder.instance(_ => Json.Null)
-  given ChecksStateEncoder: Encoder[ChecksState]                      = deriveEncoder[ChecksState]
-  given ChecksStateInprogressEncoder: Encoder[ChecksState.InProgress] = ChecksStateEncoder.narrow
-  given ChecksStateDecicedEncoder: Encoder[ChecksState.Decided]       = ChecksStateEncoder.narrow
-  given stateEncoder: Encoder.AsObject[WithdrawalData]                = deriveEncoder[WithdrawalData]
+  given Encoder[ChecksState]                      = Encoder.instance{
+    case inProgress: ChecksState.InProgress =>
+      inProgress.asJson
+    case decided: ChecksState.Decided =>
+      decided.asJson
+  }
 
+  given Encoder[WithdrawalData] = Encoder.instance {
+     case empty: WithdrawalData.Empty =>
+       empty.asJson
+     case initiated: WithdrawalData.Initiated =>
+       initiated.asJson
+     case validated: WithdrawalData.Validated =>
+       validated.asJson
+     case checking: WithdrawalData.Checking =>
+       checking.asJson
+     case checked: WithdrawalData.Checked =>
+       checked.asJson
+     case executed: WithdrawalData.Executed =>
+       executed.asJson
+     case completed: WithdrawalData.Completed =>
+       Json.fromString("Completed") 
+ }
   val routes: Route = {
     path("withdrawals") {
       get {

--- a/workflows4s-example/src/main/scala/workflows4s/example/pekko/HttpRoutes.scala
+++ b/workflows4s-example/src/main/scala/workflows4s/example/pekko/HttpRoutes.scala
@@ -13,33 +13,33 @@ import workflows4s.example.withdrawal.checks.{CheckResult, ChecksInput, ChecksSt
 import io.circe.generic.auto.*
 
 class HttpRoutes(service: WithdrawalWorkflowService)(using ioRuntime: IORuntime) extends FailFastCirceSupport {
-  given checksInput: Encoder[ChecksInput]                             = Encoder.instance(_.checks.keys.map(_.value).asJson)
-  given checksResult: Encoder[CheckResult]                            = Encoder.instance(_ => Json.Null)
-  given checksResultFinished: Encoder[CheckResult.Finished]           = Encoder.instance(_ => Json.Null)
-  given Encoder[ChecksState]                      = Encoder.instance{
+  given checksInput: Encoder[ChecksInput]                   = Encoder.instance(_.checks.keys.map(_.value).asJson)
+  given checksResult: Encoder[CheckResult]                  = Encoder.instance(_ => Json.Null)
+  given checksResultFinished: Encoder[CheckResult.Finished] = Encoder.instance(_ => Json.Null)
+  given Encoder[ChecksState]                                = Encoder.instance {
     case inProgress: ChecksState.InProgress =>
       inProgress.asJson
-    case decided: ChecksState.Decided =>
+    case decided: ChecksState.Decided       =>
       decided.asJson
   }
 
   given Encoder[WithdrawalData] = Encoder.instance {
-     case empty: WithdrawalData.Empty =>
-       empty.asJson
-     case initiated: WithdrawalData.Initiated =>
-       initiated.asJson
-     case validated: WithdrawalData.Validated =>
-       validated.asJson
-     case checking: WithdrawalData.Checking =>
-       checking.asJson
-     case checked: WithdrawalData.Checked =>
-       checked.asJson
-     case executed: WithdrawalData.Executed =>
-       executed.asJson
-     case completed: WithdrawalData.Completed =>
-       Json.fromString("Completed") 
- }
-  val routes: Route = {
+    case empty: WithdrawalData.Empty         =>
+      empty.asJson
+    case initiated: WithdrawalData.Initiated =>
+      initiated.asJson
+    case validated: WithdrawalData.Validated =>
+      validated.asJson
+    case checking: WithdrawalData.Checking   =>
+      checking.asJson
+    case checked: WithdrawalData.Checked     =>
+      checked.asJson
+    case executed: WithdrawalData.Executed   =>
+      executed.asJson
+    case completed: WithdrawalData.Completed =>
+      Json.fromString("Completed")
+  }
+  val routes: Route             = {
     path("withdrawals") {
       get {
         onSuccess(service.listWorkflows.unsafeToFuture()) { list =>

--- a/workflows4s-example/src/main/scala/workflows4s/example/pekko/Main.scala
+++ b/workflows4s-example/src/main/scala/workflows4s/example/pekko/Main.scala
@@ -31,6 +31,8 @@ object Main extends IOApp {
               WithdrawalData.Empty,
               knockerUpper,
             )
+          _ <- knockerUpper.initialize(wokeup => IO.println(s"Woke up! $wokeup"))
+          _                        <- IO(runtime.initializeShard())
           withdrawalWorkflowService = WithdrawalWorkflowService.Impl(journal, runtime)
           routes                    = HttpRoutes(withdrawalWorkflowService)
           _                        <- runHttpServer(routes)

--- a/workflows4s-example/src/main/scala/workflows4s/example/pekko/Main.scala
+++ b/workflows4s-example/src/main/scala/workflows4s/example/pekko/Main.scala
@@ -22,17 +22,18 @@ object Main extends IOApp {
       .flatTap(_ => Resource.make(IO.unit)(_ => IO(system.terminate())))
       .use(knockerUpper =>
         for {
-          journal                  <- setupJournal()
-          workflow                  = WithdrawalWorkflow(DummyWithdrawalService, ChecksEngine)
-          runtime                   =
+          journal <- setupJournal()
+          workflow = WithdrawalWorkflow(DummyWithdrawalService, ChecksEngine)
+          runtime  =
             PekkoRuntime.create[WithdrawalWorkflow.Context.Ctx](
               "withdrawal",
               workflow.workflowDeclarative,
               WithdrawalData.Empty,
               knockerUpper,
             )
-          _ <- knockerUpper.initialize(wokeup => IO.println(s"Woke up! $wokeup"))
+
           _                        <- IO(runtime.initializeShard())
+          _                        <- knockerUpper.initialize(wokeup => IO.println(s"Woke up! $wokeup"))
           withdrawalWorkflowService = WithdrawalWorkflowService.Impl(journal, runtime)
           routes                    = HttpRoutes(withdrawalWorkflowService)
           _                        <- runHttpServer(routes)


### PR DESCRIPTION
# Issue details

## 1. Missing `runtime.initializeShard` and `knockerUpper.initialize`

**Request:** `POST http://localhost:8989/withdrawals/1234`

**Error logs:**
```text
Assert: ERROR org.apache.pekko.actor.ActorSystemImpl - Error during processing of request: 'Shard type [withdrawal] must be started first. Started [] proxies []'. Completing with 500 Internal Server Error response. To change default exception handling behavior, provide a custom ExceptionHandler.
java.lang.IllegalStateException: Shard type [withdrawal] must be started first. Started [] proxies []
```

## 2. JSON encoder for ADT

**Request:** `GET http://localhost:8989/withdrawals/1234`

**Error:** stackOverflow in Json Encoder