### PR TITLE
Add ability to inspect expected signals

### DIFF
--- a/workflows4s-core/src/main/scala/workflows4s/runtime/MappedWorkflowInstance.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/runtime/MappedWorkflowInstance.scala
@@ -16,4 +16,6 @@ class MappedWorkflowInstance[F[_], G[_], State](base: WorkflowInstance[F, State]
   override def wakeup(): G[Unit] = map(base.wakeup())
 
   override def getProgress: G[WIOExecutionProgress[State]] = map(base.getProgress)
+
+  def getExpectedSignals: G[List[SignalDef[?, ?]]] = map(base.getExpectedSignals)
 }

--- a/workflows4s-core/src/main/scala/workflows4s/runtime/WorkflowInstance.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/runtime/WorkflowInstance.scala
@@ -16,6 +16,8 @@ trait WorkflowInstance[F[_], State] {
 
   def getProgress: F[WIOExecutionProgress[State]]
 
+  def getExpectedSignals: F[List[SignalDef[?, ?]]]
+
 }
 
 object WorkflowInstance {

--- a/workflows4s-core/src/main/scala/workflows4s/runtime/WorkflowInstanceBase.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/runtime/WorkflowInstanceBase.scala
@@ -40,6 +40,13 @@ trait WorkflowInstanceBase[F[_], Ctx <: WorkflowContext] extends WorkflowInstanc
     } yield wf.progress(now)
   }
 
+  override def getExpectedSignals: F[List[SignalDef[?, ?]]] = {
+    for {
+      wf  <- getWorkflow
+      now <- currentTime
+    } yield wf.liveSignals(now)
+  }
+
   override def deliverSignal[Req, Resp](signalDef: SignalDef[Req, Resp], req: Req): F[Either[WorkflowInstance.UnexpectedSignal, Resp]] = {
     def processSignal(state: ActiveWorkflow[Ctx], now: Instant): F[LockOutcome[Either[WorkflowInstance.UnexpectedSignal, Resp]]] = {
       state.handleSignal(signalDef)(req, now) match {

--- a/workflows4s-core/src/main/scala/workflows4s/wio/ActiveWorkflow.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/ActiveWorkflow.scala
@@ -17,6 +17,11 @@ case class ActiveWorkflow[Ctx <: WorkflowContext](wio: WIO.Initial[Ctx], initial
     wf.staticState
   }
 
+  def liveSignals(now: Instant): List[SignalDef[?, ?]] = {
+    val wf = effectlessProceed(now).getOrElse(this)
+    GetSignalDefsEvaluator.run(wf.wio)
+  }
+
   def handleSignal[Req, Resp](signalDef: SignalDef[Req, Resp])(req: Req, now: Instant): Option[IO[(WCEvent[Ctx], Resp)]] = {
     val wf = effectlessProceed(now).getOrElse(this)
     SignalEvaluator.handleSignal(signalDef, req, wf.wio, wf.staticState) match {

--- a/workflows4s-core/src/main/scala/workflows4s/wio/internal/GetSignalDefsEvaluator.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/internal/GetSignalDefsEvaluator.scala
@@ -1,0 +1,75 @@
+package workflows4s.wio.internal
+
+import workflows4s.wio.*
+
+private[workflows4s] object GetSignalDefsEvaluator {
+
+  def run(wio: WIO[?, ?, ?, ?]): List[SignalDef[?, ?]] = {
+    val visitor = new GetSignalDefsVisitor(wio)
+    visitor.run
+  }
+
+  private class GetSignalDefsVisitor[Ctx <: WorkflowContext, In, Err, Out <: WCState[Ctx]](
+      wio: WIO[In, Err, Out, Ctx],
+  ) extends Visitor[Ctx, In, Err, Out](wio) {
+    override type Result = List[SignalDef[?, ?]]
+
+    // Base cases
+    override def onSignal[Sig, Evt, Resp](wio: WIO.HandleSignal[Ctx, In, Out, Err, Sig, Resp, Evt]): Result = List(wio.sigDef)
+    override def onExecuted[In1](wio: WIO.Executed[Ctx, Err, Out, In1]): Result                             = Nil
+    override def onRunIO[Evt](wio: WIO.RunIO[Ctx, In, Err, Out, Evt]): Result                               = Nil
+    override def onNoop(wio: WIO.End[Ctx]): Result                                                          = Nil
+    override def onPure(wio: WIO.Pure[Ctx, In, Err, Out]): Result                                           = Nil
+    override def onTimer(wio: WIO.Timer[Ctx, In, Err, Out]): Result                                         = Nil
+    override def onAwaitingTime(wio: WIO.AwaitingTime[Ctx, In, Err, Out]): Result                           = Nil
+    override def onRecovery[Evt](wio: WIO.Recovery[Ctx, In, Err, Out, Evt]): Result                         = Nil
+
+    // Recursive cases
+    override def onDiscarded[In1](wio: WIO.Discarded[Ctx, In1]): Result                                                         = Nil
+    override def onFlatMap[Out1 <: WCState[Ctx], Err1 <: Err](wio: WIO.FlatMap[Ctx, Err1, Err, Out1, Out, In]): Result          = recurse(
+      wio.base, // the next step in FlatMap is already handled in onAndThen
+    )
+    override def onTransform[In1, Out1 <: WCState[Ctx], Err1](wio: WIO.Transform[Ctx, In1, Err1, Out1, In, Out, Err]): Result   = recurse(wio.base)
+    override def onHandleError[ErrIn, TempOut <: WCState[Ctx]](wio: WIO.HandleError[Ctx, In, Err, Out, ErrIn, TempOut]): Result = Nil
+
+    override def onCheckpoint[Evt, Out1 <: Out](wio: WIO.Checkpoint[Ctx, In, Err, Out1, Evt]): Result = recurse(wio.base)
+    override def onEmbedded[InnerCtx <: WorkflowContext, InnerOut <: WCState[InnerCtx], MappingOutput[_ <: WCState[InnerCtx]] <: WCState[Ctx]](
+        wio: WIO.Embedded[Ctx, In, Err, InnerCtx, InnerOut, MappingOutput],
+    ): Result = GetSignalDefsEvaluator.run(wio.inner)
+    override def onAndThen[Out1 <: WCState[Ctx]](wio: WIO.AndThen[Ctx, In, Err, Out1, Out]): Result   =
+      wio.first.asExecuted match {
+        case Some(first) =>
+          recurse(wio.second)
+        case None        =>
+          recurse(wio.first)
+      }
+
+    override def onHandleErrorWith[ErrIn](wio: WIO.HandleErrorWith[Ctx, In, ErrIn, Out, Err]): Result                 =
+      wio.base.asExecuted match {
+        case Some(baseExecuted) =>
+          baseExecuted.output match {
+            case Left(err) =>
+              recurse(wio.handleError)
+            case Right(_)  => Nil
+          }
+
+        case None =>
+          recurse(wio.base)
+      }
+
+    override def onLoop[BodyIn <: WCState[Ctx], BodyOut <: WCState[Ctx], ReturnIn](
+        wio: WIO.Loop[Ctx, In, Err, Out, BodyIn, BodyOut, ReturnIn],
+    ): Result = recurse(wio.current.wio)
+    override def onFork(wio: WIO.Fork[Ctx, In, Err, Out]): Result                                                     = wio.selected.map(idx => recurse(wio.branches(idx).wio)).getOrElse(Nil)
+    override def onHandleInterruption(wio: WIO.HandleInterruption[Ctx, In, Err, Out]): Result                         = recurse(wio.base) ++ recurse(wio.interruption)
+    override def onParallel[InterimState <: WCState[Ctx]](wio: WIO.Parallel[Ctx, In, Err, Out, InterimState]): Result =
+      wio.elements.flatMap(elem => recurse(elem.wio)).toList
+
+    def onRetry(wio: WIO.Retry[Ctx, In, Err, Out]): Result = {
+      recurse(wio.base)
+    }
+
+    def recurse[I1, E1, O1 <: WCState[Ctx]](wio: WIO[I1, E1, O1, Ctx]): List[SignalDef[?, ?]] =
+      new GetSignalDefsVisitor(wio).run
+  }
+}

--- a/workflows4s-core/src/test/scala/workflows4s/testing/TestRuntimeAdapter.scala
+++ b/workflows4s-core/src/test/scala/workflows4s/testing/TestRuntimeAdapter.scala
@@ -61,7 +61,8 @@ object TestRuntimeAdapter {
         inst
       }
 
-      override def getEvents: Seq[WCEvent[Ctx]] = delegate.getEvents
+      override def getEvents: Seq[WCEvent[Ctx]]                  = delegate.getEvents
+      override def getExpectedSignals: Id[List[SignalDef[?, ?]]] = delegate.getExpectedSignals
     }
   }
 
@@ -89,7 +90,8 @@ object TestRuntimeAdapter {
       }
       val delegate: WorkflowInstance[Id, WCState[Ctx]] = MappedWorkflowInstance(base, [t] => (x: IO[t]) => x.unsafeRunSync())
 
-      override def getEvents: Seq[WCEvent[Ctx]] = base.getEvents.unsafeRunSync()
+      override def getEvents: Seq[WCEvent[Ctx]]                  = base.getEvents.unsafeRunSync()
+      override def getExpectedSignals: Id[List[SignalDef[?, ?]]] = delegate.getExpectedSignals
     }
 
   }

--- a/workflows4s-core/src/test/scala/workflows4s/wio/WIOAndThenTest.scala
+++ b/workflows4s-core/src/test/scala/workflows4s/wio/WIOAndThenTest.scala
@@ -30,6 +30,7 @@ class WIOAndThenTest extends AnyFreeSpec with Matchers with EitherValues {
         assert(resp == 1)
 
         assert(wf.queryState().executed == List(stepId1, step2Id))
+        assert(wf.getExpectedSignals.isEmpty)
       }
       "handle on second" in {
         val (step1Id, step1)            = TestUtils.pure
@@ -42,6 +43,7 @@ class WIOAndThenTest extends AnyFreeSpec with Matchers with EitherValues {
         assert(resp == 1)
 
         assert(wf.queryState().executed == List(step1Id, stepId2))
+        assert(wf.getExpectedSignals.isEmpty)
       }
     }
     "proceed" - {

--- a/workflows4s-core/src/test/scala/workflows4s/wio/WIOFlatMapTest.scala
+++ b/workflows4s-core/src/test/scala/workflows4s/wio/WIOFlatMapTest.scala
@@ -26,10 +26,12 @@ class WIOFlatMapTest extends AnyFreeSpec with Matchers with EitherValues {
 
         assert(wf.queryState().executed == List())
 
+        wf.getExpectedSignals should contain theSameElementsAs (List(signalDef))
         val resp = wf.deliverSignal(signalDef, 1).value
         assert(resp == 1)
 
         assert(wf.queryState().executed == List(stepId1, step2Id))
+        assert(wf.getExpectedSignals.isEmpty)
       }
       "handle on second" in {
         val (step1Id, step1)            = TestUtils.pure
@@ -38,10 +40,12 @@ class WIOFlatMapTest extends AnyFreeSpec with Matchers with EitherValues {
         val (_, wf) = TestUtils.createInstance2(step1.flatMap(_ => step2))
         assert(wf.queryState().executed == List(step1Id))
 
+        wf.getExpectedSignals should contain theSameElementsAs (List(signalDef))
         val resp = wf.deliverSignal(signalDef, 1).value
         assert(resp == 1)
 
         assert(wf.queryState().executed == List(step1Id, stepId2))
+        assert(wf.getExpectedSignals.isEmpty)
       }
     }
     "proceed" - {

--- a/workflows4s-core/src/test/scala/workflows4s/wio/WIOHandleErrorTest.scala
+++ b/workflows4s-core/src/test/scala/workflows4s/wio/WIOHandleErrorTest.scala
@@ -43,13 +43,16 @@ class WIOHandleErrorTest extends AnyFreeSpec with Matchers with EitherValues {
       val wio                       = base.handleErrorWith(handler)
       val (_, wf)                   = TestUtils.createInstance2(wio)
 
+      wf.getExpectedSignals should contain theSameElementsAs (List(signal1))
       val response = wf.deliverSignal(signal1, 43).value
       assert(response === 43)
       assert(wf.queryState() === TestState.empty)
 
+      wf.getExpectedSignals should contain theSameElementsAs (List(signal2))
       val response2 = wf.deliverSignal(signal2, 44).value
       assert(response2 === 44)
       assert(wf.queryState() === TestState(executed = List(step2Id), errors = List(error)))
+      wf.getExpectedSignals shouldBe empty
     }
 
     "effectful handler" in {

--- a/workflows4s-core/src/test/scala/workflows4s/wio/WIOHandleInterruptionTest.scala
+++ b/workflows4s-core/src/test/scala/workflows4s/wio/WIOHandleInterruptionTest.scala
@@ -62,6 +62,7 @@ class WIOHandleInterruptionTest extends AnyFreeSpec with Matchers with OptionVal
         assert(instance.queryState() === TestState(executed = List(step1Id)))
 
         // after base is processed, interruption is no longer possible
+        instance.getExpectedSignals shouldBe empty
         val interruptionSignalResult = instance.deliverSignal(signalA, 43)
         assert(interruptionSignalResult.isLeft)
       }
@@ -70,11 +71,13 @@ class WIOHandleInterruptionTest extends AnyFreeSpec with Matchers with OptionVal
         val wf            = handleSignalB.interruptWith(interruptWithSignalA)
         val (_, instance) = TestUtils.createInstance2(wf)
 
+        instance.getExpectedSignals should contain theSameElementsAs List(signalA, signalB)
         val signalResult = instance.deliverSignal(signalB, 42).value
         assert(signalResult === 42)
         assert(instance.queryState() === TestState(executed = List(signalBStepId)))
 
         // after base is processed, interruption is no longer possible
+        instance.getExpectedSignals shouldBe empty
         val interruptionSignalResult = instance.deliverSignal(signalA, 43)
         assert(interruptionSignalResult.isLeft)
       }
@@ -83,13 +86,15 @@ class WIOHandleInterruptionTest extends AnyFreeSpec with Matchers with OptionVal
         val wf            = handleSignalB.interruptWith(interruptWithSignalA)
         val (_, instance) = TestUtils.createInstance2(wf)
 
+        instance.getExpectedSignals should contain theSameElementsAs List(signalA, signalB)
         val signalResult = instance.deliverSignal(signalA, 42).value
         assert(signalResult === 42)
 
         // after processing, state is coming from interruption flow
         assert(instance.queryState() === TestState(executed = List(signalAStepId)))
 
-        // after base is processed, interruption is no longer possible
+        // after interruption is processed, interruption is no longer possible
+        instance.getExpectedSignals shouldBe empty
         val interruptionSignalResult = instance.deliverSignal(signalA, 43)
         assert(interruptionSignalResult.isLeft)
       }

--- a/workflows4s-core/src/test/scala/workflows4s/wio/WIOHandleSignalTest.scala
+++ b/workflows4s-core/src/test/scala/workflows4s/wio/WIOHandleSignalTest.scala
@@ -10,6 +10,7 @@ import workflows4s.wio.WIO.HandleSignal
 
 import java.time.Instant
 import scala.util.Random
+import workflows4s.wio.internal.GetSignalDefsEvaluator
 
 class WIOHandleSignalTest extends AnyFreeSpec with Matchers {
 
@@ -26,6 +27,9 @@ class WIOHandleSignalTest extends AnyFreeSpec with Matchers {
         .produceResponse((input, request) => s"response($input, $request)")
         .done
         .toWorkflow("initialState")
+
+      // check SignalDef list
+      GetSignalDefsEvaluator.run(wf.wio) should contain(mySignalDef)
 
       // Act
       val signalResult = wf.handleSignal(mySignalDef)(42, Instant.now)
@@ -54,6 +58,8 @@ class WIOHandleSignalTest extends AnyFreeSpec with Matchers {
         .produceResponse(ignore)
         .done
         .toWorkflow("initialState")
+
+      GetSignalDefsEvaluator.run(wf.wio) should contain(validSignalDef)
 
       val unexpectedSignalResult = wf.handleSignal(unexpectedSignalDef)("unexpected", Instant.now)
 

--- a/workflows4s-core/src/test/scala/workflows4s/wio/WIOLoopTest.scala
+++ b/workflows4s-core/src/test/scala/workflows4s/wio/WIOLoopTest.scala
@@ -132,9 +132,13 @@ class WIOLoopTest extends AnyFreeSpec with Matchers with OptionValues with Eithe
         val (loopFinishedId, wf) = createLoop(signalStep, signalStepId, None, iterations)
         val (_, instance)        = TestUtils.createInstance2(wf)
 
+        instance.getExpectedSignals should contain theSameElementsAs (List(signalDef))
+
         val response1 = instance.deliverSignal(signalDef, 1).value
         assert(response1 == 1)
         assert(instance.queryState().executed == List(signalStepId))
+
+        instance.getExpectedSignals should contain theSameElementsAs (List(signalDef))
 
         // Deliver signal for second iteration
         val response2 = instance.deliverSignal(signalDef, 2).value
@@ -153,16 +157,19 @@ class WIOLoopTest extends AnyFreeSpec with Matchers with OptionValues with Eithe
         val (loopFinishedId, wf) = createLoop(step1, step1Id, Some(signalStep), iterations)
         val (_, instance)        = TestUtils.createInstance2(wf)
 
+        instance.getExpectedSignals should contain theSameElementsAs (List(signalDef))
         val response1 = instance.deliverSignal(signalDef, 1).value
         assert(response1 == 1)
         assert(instance.queryState().executed == List(step1Id, signalStepId, step1Id))
 
+        instance.getExpectedSignals should contain theSameElementsAs (List(signalDef))
         // Deliver signal for second iteration
         val response2 = instance.deliverSignal(signalDef, 2).value
         assert(response2 == 2)
         assert(instance.queryState().executed == List(step1Id, signalStepId, step1Id, signalStepId, step1Id, loopFinishedId))
 
         // Signal should no longer be accepted
+        instance.getExpectedSignals shouldBe empty
         assert(instance.deliverSignal(signalDef, 3).isLeft)
       }
     }

--- a/workflows4s-core/src/test/scala/workflows4s/wio/WIOParallelTest.scala
+++ b/workflows4s-core/src/test/scala/workflows4s/wio/WIOParallelTest.scala
@@ -45,11 +45,13 @@ class WIOParallelTest extends AnyFreeSpec with Matchers with OptionValues with E
       val (_, instance) = TestUtils.createInstance2(wf)
       assert(instance.queryState().executed == List())
 
+      instance.getExpectedSignals should contain theSameElementsAs (List(signalDef1, signalDef2))
       val response1 = instance.deliverSignal(signalDef1, 1).value
       assert(response1 == 1)
       assert(instance.queryState().executed == List(singlaStepId1))
       assert(instance.deliverSignal(signalDef1, 2).isLeft)
 
+      instance.getExpectedSignals should contain theSameElementsAs (List(signalDef2))
       val response2 = instance.deliverSignal(signalDef2, 2).value
       assert(response2 == 2)
       assert(instance.queryState().executed == List(singlaStepId1, singlaStepId2, parStepId))

--- a/workflows4s-core/src/test/scala/workflows4s/wio/internal/GetSignalDefsEvaluatorTest.scala
+++ b/workflows4s-core/src/test/scala/workflows4s/wio/internal/GetSignalDefsEvaluatorTest.scala
@@ -1,0 +1,84 @@
+package workflows4s.wio.internal
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import workflows4s.testing.TestUtils
+import workflows4s.wio.{TestCtx2, TestState, WIO}
+import cats.effect.IO
+import java.time.Duration
+
+class GetSignalDefsEvaluatorTest extends AnyFreeSpec with Matchers {
+
+  "GetSignalDefsEvaluator" - {
+
+    "for a simple HandleSignal" - {
+      "should return the SignalDef" in {
+        val (signalDef, _, wio) = TestUtils.signal
+        GetSignalDefsEvaluator.run(wio).should(contain).theSameElementsAs(List(signalDef))
+      }
+
+      "should return an empty list if the signal is executed" in {
+        val (_, _, wio) = TestUtils.signal
+        val executedWio = WIO.Executed(wio, Right(TestState(Nil, Nil)), TestState(Nil, Nil), 1)
+        GetSignalDefsEvaluator.run(executedWio).shouldBe(empty)
+      }
+
+      "should return an empty list if the signal is discarded" in {
+        val (_, _, wio)  = TestUtils.signal
+        val discardedWio = WIO.Discarded(wio, TestState(Nil, Nil))
+        GetSignalDefsEvaluator.run(discardedWio).shouldBe(empty)
+      }
+    }
+
+    "for an AndThen structure" - {
+      "should only return the signal from the first, un-executed step" in {
+        val (signalDef1, _, step1) = TestUtils.signal
+        val (_, _, step2)          = TestUtils.signal
+        val wio                    = step1 >>> step2
+        GetSignalDefsEvaluator.run(wio).should(contain).theSameElementsAs(List(signalDef1))
+      }
+
+      "should return the signal from the second step if the first is executed" in {
+        val (signalDef1, _, step1) = TestUtils.signal
+        val (signalDef2, _, step2) = TestUtils.signal
+        val executedStep1          = WIO.Executed(step1, Right(TestState(Nil, Nil)), TestState(Nil, Nil), 1)
+        val wio                    = executedStep1 >>> step2
+        GetSignalDefsEvaluator.run(wio).should(contain).theSameElementsAs(List(signalDef2))
+      }
+    }
+
+    "for a FlatMap structure" - {
+      "should return the signal from the base" in {
+        val (signalDef, _, base) = TestUtils.signal
+        val wio                  = base.flatMap(_ => TestCtx2.WIO.pure(TestState(Nil, Nil)).done)
+        GetSignalDefsEvaluator.run(wio) should contain(signalDef)
+      }
+    }
+
+    "for a Retry structure" - {
+      "should return the signal from the base" in {
+        val (signalDef, _, base) = TestUtils.signal
+        val retryDelay           = Duration.ofSeconds(13)
+        val wio                  = base.retryIn { case _ => retryDelay }
+        GetSignalDefsEvaluator.run(wio) should contain(signalDef)
+      }
+    }
+
+    "for a HandleErrorWith structure" - {
+      "should return the signal from the base if the base has not failed" in {
+        val (signalDef, _, base) = TestUtils.signal
+        val handler              = TestCtx2.WIO.pure(TestState(Nil, Nil)).done
+        val wio                  = base.handleErrorWith(handler)
+        GetSignalDefsEvaluator.run(wio).should(contain).theSameElementsAs(List(signalDef))
+      }
+
+      "should return the signal from the handler if the base has failed" in {
+        val (_, _, handleSignal) = TestUtils.signal
+        val handler              = TestCtx2.WIO.pure(TestState(Nil, Nil)).done
+        val base                 = WIO.Executed(handleSignal, Left("error"), TestState(Nil), 0)
+        val wio                  = base.handleErrorWith(handler)
+        GetSignalDefsEvaluator.run(wio).shouldBe(empty)
+      }
+    }
+  }
+}

--- a/workflows4s-pekko/src/test/scala/workflows4s/runtime/pekko/PekkoRuntimeAdapter.scala
+++ b/workflows4s-pekko/src/test/scala/workflows4s/runtime/pekko/PekkoRuntimeAdapter.scala
@@ -79,7 +79,8 @@ class PekkoRuntimeAdapter[Ctx <: WorkflowContext](entityKeyPrefix: String)(impli
         stateQueryTimeout = Timeout(3.seconds),
       )
 
-    val delegate: WorkflowInstance[Id, WCState[Ctx]] = MappedWorkflowInstance(base, [t] => (x: Future[t]) => Await.result(x, 3.seconds))
+    val delegate: WorkflowInstance[Id, WCState[Ctx]]           = MappedWorkflowInstance(base, [t] => (x: Future[t]) => Await.result(x, 3.seconds))
+    override def getExpectedSignals: Id[List[SignalDef[?, ?]]] = delegate.getExpectedSignals
   }
 
   override def recover(first: Actor): Actor = {


### PR DESCRIPTION
 [Issue #131](https://github.com/business4s/workflows4s/issues/131)
    This introduces `WorkflowInstance.getExpectedSignals` , which allows querying the signals a workflow is currently waiting for. This is useful for introspection and debugging.

    - Added  WorkflowInstance.getExpectedSignals
    - Implemented new vistor  to extract the list of expected signals from a WIO.
    - Updated tests to verify the new functionality.