### PR TITLE
feat: POC for experimental path-dependent WIO modularity

### DIFF
--- a/workflows4s-core/src/main/scala/workflows4s/wio/experimental/PathDependentWIO.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/experimental/PathDependentWIO.scala
@@ -7,17 +7,17 @@ trait Workflow {
   sealed trait WIO[-In, +Err, +Out] {
     def flatMap[Err1 >: Err, Out1](f: Out => WIO[Out, Err1, Out1]): WIO[In, Err1, Out1] =
       WIO.FlatMap(this, f)
-    
+
     def map[Out1](f: Out => Out1): WIO[In, Err, Out1] =
       this.flatMap(out => WIO.Pure(f(out)))
   }
 
   object WIO {
     case class Pure[+Out](value: Out) extends WIO[Any, Nothing, Out]
-    
+
     case class FlatMap[In, Err, Out, Out1](
-      base: WIO[In, Err, Out],
-      f: Out => WIO[Out, Err, Out1]
+        base: WIO[In, Err, Out],
+        f: Out => WIO[Out, Err, Out1],
     ) extends WIO[In, Err, Out1]
   }
 }

--- a/workflows4s-core/src/test/scala/workflows4s/wio/experimental/PathDependentWIOTest.scala
+++ b/workflows4s-core/src/test/scala/workflows4s/wio/experimental/PathDependentWIOTest.scala
@@ -7,17 +7,17 @@ class PathDependentWIOTest extends AnyFreeSpec with Matchers {
 
   "PathDependentWIO" - {
     "should support basic types" in {
-       object MyWorkflow extends Workflow {
-         type Event = String
-         type State = Int
-       }
+      object MyWorkflow extends Workflow {
+        type Event = String
+        type State = Int
+      }
 
-       val step1: MyWorkflow.WIO[Any, Nothing, Int] = MyWorkflow.WIO.Pure(42)
-       val step2: MyWorkflow.WIO[Int, Nothing, String] = step1.map(_.toString)
-       println(step2)
+      val step1: MyWorkflow.WIO[Any, Nothing, Int]    = MyWorkflow.WIO.Pure(42)
+      val step2: MyWorkflow.WIO[Int, Nothing, String] = step1.map(_.toString)
+      println(step2)
 
-       // Just verifying that it compiles and types are correct
-       succeed
+      // Just verifying that it compiles and types are correct
+      succeed
     }
   }
 


### PR DESCRIPTION
## Description
This PR introduces a Proof of Concept (POC) for using path-dependent types in `WIO`, addressing #187. 

The goal is to experiment with removing the `Ctx` type parameter from `WIO` by encapsulating `Event` and `State` within a `Workflow` trait.

## Changes
- Created a new package `workflows4s.wio.experimental`.
- Introduced `PathDependentWIO.scala` containing a `Workflow` trait with abstract `Event` and `State` types, and a nested `WIO` trait that utilizes these types.
- Added `PathDependentWIOTest.scala` to verify that the new structure compiles and can be used to define simple workflows.

## Verification
- Added a new test suite `PathDependentWIOTest`.
- Verified compilation and basic execution via `sbt`.

## Related Issue
Fixes #187

@Krever 