### PR TITLE
fix(doobie): skip Postgres tests when Docker is unavailable

### DIFF
--- a/workflows4s-doobie/src/test/scala/workflows4s/doobie/postgres/testing/PostgresSuite.scala
+++ b/workflows4s-doobie/src/test/scala/workflows4s/doobie/postgres/testing/PostgresSuite.scala
@@ -7,11 +7,34 @@ import com.dimafeng.testcontainers.scalatest.TestContainerForAll
 import doobie.*
 import doobie.implicits.*
 import doobie.util.transactor.Transactor
-import org.scalatest.Suite
+import org.scalatest.{BeforeAndAfterAll, Suite}
 
-trait PostgresSuite extends TestContainerForAll { self: Suite =>
+trait PostgresSuite extends TestContainerForAll with BeforeAndAfterAll { self: Suite =>
 
   override val containerDef: PostgreSQLContainer.Def = PostgreSQLContainer.Def()
+
+  override def beforeAll(): Unit = {
+    if isDockerAvailable() then {
+      super.beforeAll()
+    } else {
+      cancel("Docker is not available")
+    }
+  }
+
+  private def isDockerAvailable(): Boolean = {
+    try {
+      import scala.sys.process.*
+      import scala.concurrent.{Await, Future}
+      import scala.concurrent.duration.*
+      import scala.concurrent.ExecutionContext.Implicits.global
+      val future = Future {
+        Process("docker info").!(ProcessLogger(_ => ())) == 0
+      }
+      Await.result(future, 5.seconds)
+    } catch {
+      case _: Exception => false
+    }
+  }
 
   var xa: Transactor[IO] = scala.compiletime.uninitialized
 


### PR DESCRIPTION
Adds a Docker availability check to PostgresSuite before running tests. If Docker is not available, the tests are skipped with a meaningful message instead of failing. Includes a 5-second timeout to prevent CI from hanging if the Docker daemon is unresponsive.