### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Sonatype Nexus (Snapshots)](https://img.shields.io/nexus/s/org.business4s/workflows4s-core_3?server=https%3A%2F%2Foss.sonatype.org&style=flat-square)
 
 **Workflows4s** is a library that helps in building long-running stateful processes sometimes called workflows. It tries
-to merge Temporal's execution model, BMPN rendering and native event-sourcing while removing the most of the magic from the
+to merge Temporal's execution model, BPMN rendering and native event-sourcing while removing the most of the magic from the
 solution.
 
 See the [**Website**](https://business4s.github.io/workflows4s/) for details and join our [**Discord**](https://bit.ly/business4s-discord) for discussions.


### PR DESCRIPTION
Came here from your [Medium post](https://medium.com/business4s-blog/business4s-h2-2025-highlights-fdcec3f9c3f8) and noticed a typo in the README while looking around.

BMPN → BPMN