### PR TITLE
Expose instance ID to WIO

### DIFF
--- a/workflows4s-core/src/main/scala/workflows4s/wio/ActiveWorkflow.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/ActiveWorkflow.scala
@@ -30,7 +30,7 @@ case class ActiveWorkflow[Ctx <: WorkflowContext](id: WorkflowInstanceId, wio: W
 
   def handleSignal[Req, Resp](signalDef: SignalDef[Req, Resp])(req: Req): SignalResult[WCEvent[Ctx], Resp] = {
     val wf = effectlessProceed
-    SignalEvaluator.handleSignal(signalDef, req, wf.wio, wf.staticState)
+    SignalEvaluator.handleSignal(signalDef, req, wf.wio, wf.staticState, id)
   }
 
   def handleEvent(event: WCEvent[Ctx]): Option[ActiveWorkflow[Ctx]] = {
@@ -44,7 +44,7 @@ case class ActiveWorkflow[Ctx <: WorkflowContext](id: WorkflowInstanceId, wio: W
 
   def proceed(now: Instant): WakeupResult[WCEvent[Ctx]] = {
     val wf = effectlessProceed
-    RunIOEvaluator.proceed(wf.wio, wf.staticState, now)
+    RunIOEvaluator.proceed(wf.wio, wf.staticState, now, id)
   }
 
   def progress: WIOExecutionProgress[WCState[Ctx]] = effectlessProceed.wio.toProgress
@@ -52,7 +52,7 @@ case class ActiveWorkflow[Ctx <: WorkflowContext](id: WorkflowInstanceId, wio: W
   // moves forward as far as possible
   private def effectlessProceed: ActiveWorkflow[Ctx] =
     ProceedEvaluator
-      .proceed(wio, initialState)
+      .proceed(wio, initialState, id)
       .newFlow
       .map(newWio => this.copy(wio = newWio))
       .map(x => x.effectlessProceed)

--- a/workflows4s-core/src/main/scala/workflows4s/wio/WIO.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/WIO.scala
@@ -42,7 +42,7 @@ object WIO {
 
   case class HandleSignal[Ctx <: WorkflowContext, -In, +Out <: WCState[Ctx], +Err, Req, Resp, Evt](
       sigDef: SignalDef[Req, Resp],
-      sigHandler: SignalHandler[Req, Evt, In],
+      sigHandler: SignalHandler[Req, Evt, In, WCState[Ctx]],
       evtHandler: EventHandler[In, Either[Err, Out], WCEvent[Ctx], Evt],
       responseProducer: (In, Evt, Req) => Resp,
       meta: HandleSignal.Meta, // TODO here and everywhere else, we could use WIOMeta directly
@@ -57,7 +57,7 @@ object WIO {
   }
 
   case class RunIO[Ctx <: WorkflowContext, -In, +Err, +Out <: WCState[Ctx], Evt](
-      buildIO: In => IO[Evt],
+      buildIO: WIOContext[WCState[Ctx]] => In => IO[Evt],
       evtHandler: EventHandler[In, Either[Err, Out], WCEvent[Ctx], Evt],
       meta: RunIO.Meta,
   ) extends WIO[In, Err, Out, Ctx]
@@ -67,7 +67,7 @@ object WIO {
   }
 
   case class Pure[Ctx <: WorkflowContext, -In, +Err, +Out <: WCState[Ctx]](
-      value: In => Either[Err, Out],
+      value: WIOContext[WCState[Ctx]] => In => Either[Err, Out],
       meta: Pure.Meta,
   ) extends WIO[In, Err, Out, Ctx]
 
@@ -243,11 +243,14 @@ object WIO {
 
     sealed trait Mode[Ctx <: WorkflowContext, -In, +Err, +Out]
     object Mode {
-      case class Stateless[Ctx <: WorkflowContext, -In](errorHandler: (In, Throwable, WCState[Ctx], Instant) => IO[Retry.Stateless.Result])
-          extends Mode[Ctx, In, Nothing, Nothing]
+      case class Stateless[Ctx <: WorkflowContext, -In](
+          errorHandler: WIOContext[WCState[Ctx]] => (In, Throwable, WCState[Ctx], Instant) => IO[Retry.Stateless.Result],
+      ) extends Mode[Ctx, In, Nothing, Nothing]
 
       case class Stateful[Ctx <: WorkflowContext, Evt <: WCEvent[Ctx], -In, Err, +Out <: WCState[Ctx], RetryState](
-          errorHandler: ((stepInput: In, error: Throwable, workflowState: WCState[Ctx], retryState: Option[RetryState])) => IO[
+          errorHandler: WIOContext[WCState[Ctx]] => (
+              (stepInput: In, error: Throwable, workflowState: WCState[Ctx], retryState: Option[RetryState]),
+          ) => IO[
             Retry.Stateful.Result[Evt],
           ],
           eventHandler: EventHandler[(In, WCState[Ctx], Option[RetryState]), Either[RetryState, Either[Err, Out]], WCEvent[Ctx], Evt],
@@ -285,7 +288,7 @@ object WIO {
   // This could also allow for raising errors.
   case class Checkpoint[Ctx <: WorkflowContext, -In, +Err, Out <: WCState[Ctx], Evt](
       base: WIO[In, Err, Out, Ctx],
-      genEvent: (In, Out) => IO[Evt],
+      genEvent: WIOContext[WCState[Ctx]] => (In, Out) => IO[Evt],
       eventHandler: EventHandler[In, Out, WCEvent[Ctx], Evt],
   ) extends WIO[In, Err, Out, Ctx]
 

--- a/workflows4s-core/src/main/scala/workflows4s/wio/WIOContext.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/WIOContext.scala
@@ -1,0 +1,12 @@
+package workflows4s.wio
+
+import workflows4s.runtime.WorkflowInstanceId
+
+/** Runtime context not specific to the current step.
+  */
+final case class WIOContext[+State](instanceId: WorkflowInstanceId, currentState: State)
+
+object WIOContext {
+  def instanceId(using ctx: WIOContext[?]): WorkflowInstanceId = ctx.instanceId
+  def currentState[S](using ctx: WIOContext[S]): S             = ctx.currentState
+}

--- a/workflows4s-core/src/main/scala/workflows4s/wio/WIOMethods.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/WIOMethods.scala
@@ -46,12 +46,12 @@ trait WIOMethods[Ctx <: WorkflowContext, -In, +Err, +Out <: WCState[Ctx]] { self
     WIO.HandleInterruption(this, interruption.handler, WIO.HandleInterruption.InterruptionStatus.Pending, interruption.tpe)
 
   def checkpointed[Evt <: WCEvent[Ctx], In1 <: In, Out1 >: Out <: WCState[Ctx]](
-      genEvent: (In1, Out1) => Evt,
+      genEvent: WIOContext[WCState[Ctx]] ?=> (In1, Out1) => Evt,
       handleEvent: (In1, Evt) => Out1,
   )(using evtCt: ClassTag[Evt]): WIO[In1, Err, Out1, Ctx] = {
     WIO.Checkpoint(
       this,
-      (a: In1, b: Out1) => genEvent(a, b).pure[IO],
+      (ctx: WIOContext[WCState[Ctx]]) => (a: In1, b: Out1) => genEvent(using ctx)(a, b).pure[IO],
       EventHandler.partial[WCEvent[Ctx], In1, Out1, Evt](identity, handleEvent),
     )
   }

--- a/workflows4s-core/src/main/scala/workflows4s/wio/builders/DraftBuilder.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/builders/DraftBuilder.scala
@@ -19,7 +19,7 @@ object DraftBuilder {
       def signal(name: String = null, error: String = null)(using autoName: sourcecode.Name): WIO.Draft[Ctx]                                  =
         WIO.HandleSignal(
           draftSignal,
-          SignalHandler[Unit, Unit, Any]((_, _) => ???),
+          SignalHandler[Unit, Unit, Any, WCState[Ctx]](_ => (_, _) => ???),
           dummyEventHandler,
           (_, _, _) => (), // responseProducer
           WIO.HandleSignal.Meta(
@@ -96,7 +96,7 @@ object DraftBuilder {
         val draftSignalHandling = WIO
           .HandleSignal(
             draftSignal,
-            SignalHandler[Unit, Unit, WCState[Ctx]]((_, _) => ???),
+            SignalHandler[Unit, Unit, WCState[Ctx], WCState[Ctx]](_ => (_, _) => ???),
             dummyEventHandler[WCEvent[Ctx], Unit],
             (_, _, _) => (), // responseProducer
             WIO.HandleSignal.Meta(
@@ -133,10 +133,10 @@ object DraftBuilder {
         WIO
           .Retry(
             base,
-            WIO.Retry.Mode.Stateless((_: Any, _: Throwable, _: WCState[Ctx], _: java.time.Instant) => ???),
+            WIO.Retry.Mode.Stateless(_ => (_: Any, _: Throwable, _: WCState[Ctx], _: java.time.Instant) => ???),
           )
       }
-      def checkpoint(base: WIO.Draft[Ctx]): WIO.Draft[Ctx] = WIO.Checkpoint(base, (_, _) => ???, dummyEventHandler)
+      def checkpoint(base: WIO.Draft[Ctx]): WIO.Draft[Ctx] = WIO.Checkpoint(base, _ => (_, _) => ???, dummyEventHandler)
 
       object syntax {
         extension (base: WIO.Draft[Ctx]) {

--- a/workflows4s-core/src/main/scala/workflows4s/wio/builders/HandleSignalBuilder.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/builders/HandleSignalBuilder.scala
@@ -20,12 +20,13 @@ object HandleSignalBuilder {
 
       class Step1[Input] {
 
-        def withSideEffects[Evt <: WCEvent[Ctx]](f: (Input, Req) => IO[Evt])(using evtCt: ClassTag[Evt]): Step2[Evt] = Step2(f, evtCt)
+        def withSideEffects[Evt <: WCEvent[Ctx]](f: WIOContext[WCState[Ctx]] ?=> (Input, Req) => IO[Evt])(using evtCt: ClassTag[Evt]): Step2[Evt] =
+          Step2(ctx => f(using ctx), evtCt)
 
-        def purely[Evt <: WCEvent[Ctx]](f: (Input, Req) => Evt)(using evtCt: ClassTag[Evt]): Step2[Evt] =
-          Step2((x, y) => IO.pure(f(x, y)), evtCt)
+        def purely[Evt <: WCEvent[Ctx]](f: WIOContext[WCState[Ctx]] ?=> (Input, Req) => Evt)(using evtCt: ClassTag[Evt]): Step2[Evt] =
+          Step2(ctx => (x, y) => IO.pure(f(using ctx)(x, y)), evtCt)
 
-        class Step2[Evt <: WCEvent[Ctx]](signalHandler: (Input, Req) => IO[Evt], evtCt: ClassTag[Evt]) {
+        class Step2[Evt <: WCEvent[Ctx]](signalHandler: WIOContext[WCState[Ctx]] => (Input, Req) => IO[Evt], evtCt: ClassTag[Evt]) {
 
           def handleEvent[Out <: WCState[Ctx]](f: (Input, Evt) => Out): Step3[Nothing, Out] =
             Step3({ (x, y) => Right(f(x, y)) }, ErrorMeta.noError)
@@ -58,7 +59,7 @@ object HandleSignalBuilder {
               def done: WIO.IHandleSignal[Input, Err, Out, Ctx] = {
                 val eh: EventHandler[Input, Either[Err, Out], WCEvent[Ctx], Evt] =
                   EventHandler.partial[WCEvent[Ctx], Input, Either[Err, Out], Evt](identity, eventHandler)(using evtCt)
-                val sh: SignalHandler[Req, Evt, Input]                           = SignalHandler(signalHandler)
+                val sh: SignalHandler[Req, Evt, Input, WCState[Ctx]]             = SignalHandler(signalHandler)
                 val meta                                                         = HandleSignal.Meta(errorMeta, signalName.getOrElse(signalDef.name), operationName)
                 WIO.HandleSignal(signalDef, sh, eh, responseBuilder, meta)
               }

--- a/workflows4s-core/src/main/scala/workflows4s/wio/builders/InterruptionBuilder.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/builders/InterruptionBuilder.scala
@@ -24,12 +24,13 @@ object InterruptionBuilder {
 
     class SignalInterruptionStep1[Req, Resp](signalDef: SignalDef[Req, Resp]) {
 
-      def handleAsync[Evt <: WCEvent[Ctx]](f: (Input, Req) => IO[Evt])(using evtCt: ClassTag[Evt]): Step2[Evt] = Step2(f, evtCt)
+      def handleAsync[Evt <: WCEvent[Ctx]](f: WIOContext[WCState[Ctx]] ?=> (Input, Req) => IO[Evt])(using evtCt: ClassTag[Evt]): Step2[Evt] =
+        Step2(ctx => f(using ctx), evtCt)
 
-      def handleSync[Evt <: WCEvent[Ctx]](f: (Input, Req) => Evt)(using evtCt: ClassTag[Evt]): Step2[Evt] =
-        Step2((x, y) => IO.pure(f(x, y)), evtCt)
+      def handleSync[Evt <: WCEvent[Ctx]](f: WIOContext[WCState[Ctx]] ?=> (Input, Req) => Evt)(using evtCt: ClassTag[Evt]): Step2[Evt] =
+        Step2(ctx => (x, y) => IO.pure(f(using ctx)(x, y)), evtCt)
 
-      class Step2[Evt <: WCEvent[Ctx]](signalHandler: (Input, Req) => IO[Evt], evtCt: ClassTag[Evt]) {
+      class Step2[Evt <: WCEvent[Ctx]](signalHandler: WIOContext[WCState[Ctx]] => (Input, Req) => IO[Evt], evtCt: ClassTag[Evt]) {
 
         def handleEvent[Out <: WCState[Ctx]](f: (Input, Evt) => Out): Step3[Nothing, Out] =
           Step3({ (x, y) => Right(f(x, y)) }, ErrorMeta.noError)
@@ -58,7 +59,7 @@ object InterruptionBuilder {
             private def source(operationName: Option[String], signalName: Option[String]): WIO[Input, Err, Out, Ctx] = {
               val eh: EventHandler[Input, Either[Err, Out], WCEvent[Ctx], Evt]         =
                 EventHandler.partial[WCEvent[Ctx], Input, Either[Err, Out], Evt](identity, eventHandler)(using evtCt)
-              val sh: SignalHandler[Req, Evt, Input]                                   = SignalHandler(signalHandler)
+              val sh: SignalHandler[Req, Evt, Input, WCState[Ctx]]                     = SignalHandler(signalHandler)
               val meta                                                                 = WIO.HandleSignal.Meta(errorMeta, signalName.getOrElse(ModelUtils.getPrettyNameForClass(signalDef.reqCt)), operationName)
               val handleSignal: WIO.HandleSignal[Ctx, Input, Out, Err, Req, Resp, Evt] = WIO.HandleSignal(signalDef, sh, eh, responseBuilder, meta)
               handleSignal

--- a/workflows4s-core/src/main/scala/workflows4s/wio/builders/PureBuilder.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/builders/PureBuilder.scala
@@ -2,7 +2,7 @@ package workflows4s.wio.builders
 
 import cats.implicits.catsSyntaxEitherId
 import workflows4s.wio.model.ModelUtils
-import workflows4s.wio.{ErrorMeta, WCState, WIO, WorkflowContext}
+import workflows4s.wio.{ErrorMeta, WCState, WIO, WIOContext, WorkflowContext}
 
 object PureBuilder {
 
@@ -12,25 +12,34 @@ object PureBuilder {
 
     case class Step1() {
 
-      def apply[O <: WCState[Ctx]](value: => O): Step2[Any, Nothing, O] = Step2[Any, Nothing, O](_ => Right(value), None)
+      def apply[O <: WCState[Ctx]](value: WIOContext[WCState[Ctx]] ?=> O): Step2[Any, Nothing, O] =
+        Step2[Any, Nothing, O](ctx => _ => Right(value(using ctx)), None)
 
-      def error[Err](value: => Err)(using em: ErrorMeta[Err]): Step2[Any, Err, Nothing] = Step2[Any, Err, Nothing](_ => Left(value), None)
+      def error[Err](value: WIOContext[WCState[Ctx]] ?=> Err)(using em: ErrorMeta[Err]): Step2[Any, Err, Nothing] =
+        Step2[Any, Err, Nothing](ctx => _ => Left(value(using ctx)), None)
 
       def makeFrom[In]: MakeStep[In] = MakeStep[In]()
 
       case class MakeStep[In]() {
-        def apply[Err, Out <: WCState[Ctx]](f: In => Either[Err, Out])(using em: ErrorMeta[Err]): Step2[In, Err, Out] = Step2(f, None)
+        def apply[Err, Out <: WCState[Ctx]](f: WIOContext[WCState[Ctx]] ?=> In => Either[Err, Out])(using em: ErrorMeta[Err]): Step2[In, Err, Out] =
+          Step2(ctx => f(using ctx), None)
 
-        def value[O <: WCState[Ctx]](f: In => O): Step2[In, Nothing, O] = Step2[In, Nothing, O](f.andThen(_.asRight), None)
+        def value[O <: WCState[Ctx]](f: WIOContext[WCState[Ctx]] ?=> In => O): Step2[In, Nothing, O] =
+          Step2[In, Nothing, O](ctx => (f(using ctx)).andThen(_.asRight), None)
 
-        def error[Err](f: In => Err)(using em: ErrorMeta[Err]): Step2[In, Err, Nothing] = Step2[In, Err, Nothing](f.andThen(_.asLeft), None)
+        def error[Err](f: WIOContext[WCState[Ctx]] ?=> In => Err)(using em: ErrorMeta[Err]): Step2[In, Err, Nothing] =
+          Step2[In, Err, Nothing](ctx => (f(using ctx)).andThen(_.asLeft), None)
 
-        def errorOpt[Err, Out >: In <: WCState[Ctx]](f: In => Option[Err])(using em: ErrorMeta[Err]): Step2[In, Err, Out] =
-          Step2[In, Err, Out](s => f(s).map(Left(_)).getOrElse(Right(s: In)), None)
+        def errorOpt[Err, Out >: In <: WCState[Ctx]](f: WIOContext[WCState[Ctx]] ?=> In => Option[Err])(using
+            em: ErrorMeta[Err],
+        ): Step2[In, Err, Out] =
+          Step2[In, Err, Out](ctx => s => (f(using ctx))(s).map(Left(_)).getOrElse(Right(s: In)), None)
 
       }
 
-      case class Step2[In, Err, Out <: WCState[Ctx]](f: In => Either[Err, Out], name: Option[String])(using em: ErrorMeta[Err]) {
+      case class Step2[In, Err, Out <: WCState[Ctx]](f: WIOContext[WCState[Ctx]] => In => Either[Err, Out], name: Option[String])(using
+          em: ErrorMeta[Err],
+      ) {
 
         def named(name: String): WIO[In, Err, Out, Ctx] = this.copy(name = Some(name)).done
 

--- a/workflows4s-core/src/main/scala/workflows4s/wio/builders/RetryBuilder.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/builders/RetryBuilder.scala
@@ -2,7 +2,7 @@ package workflows4s.wio.builders
 
 import cats.effect.IO
 import workflows4s.wio.internal.EventHandler
-import workflows4s.wio.{WCEvent, WCState, WIO, WorkflowContext}
+import workflows4s.wio.{WCEvent, WCState, WIO, WIOContext, WorkflowContext}
 
 import java.time.{Duration, Instant}
 import scala.reflect.ClassTag
@@ -15,23 +15,26 @@ object RetryBuilder {
 
       type HandlerInput = (stepInput: In, error: Throwable, workflowState: WCState[Ctx])
 
-      def wakeupAt(onError: HandlerInput => IO[Option[Instant]]): WIO[In, Err, Out, Ctx] = {
-        val mode = WIO.Retry.Mode.Stateless[Ctx, In]((in, err, state, _) =>
-          onError(in, err, state).map({
-            case Some(value) => WIO.Retry.Stateless.Result.ScheduleWakeup(value)
-            case None        => WIO.Retry.Stateless.Result.Ignore
-          }),
+      def wakeupAt(onError: WIOContext[WCState[Ctx]] ?=> HandlerInput => IO[Option[Instant]]): WIO[In, Err, Out, Ctx] = {
+        val mode = WIO.Retry.Mode.Stateless[Ctx, In](ctx =>
+          (in, err, state, _) =>
+            (onError(using ctx))(in, err, state).map({
+              case Some(value) => WIO.Retry.Stateless.Result.ScheduleWakeup(value)
+              case None        => WIO.Retry.Stateless.Result.Ignore
+            }),
         )
         WIO.Retry(base, mode)
       }
 
       def wakeupIn(onError: PartialFunction[Throwable, Duration]): WIO[In, Err, Out, Ctx] = {
-        val mode = WIO.Retry.Mode.Stateless[Ctx, In]((_, err, _, now) => {
-          IO.pure(onError.lift(err) match {
-            case Some(backoff) => WIO.Retry.Stateless.Result.ScheduleWakeup(now.plus(backoff))
-            case None          => WIO.Retry.Stateless.Result.Ignore
-          })
-        })
+        val mode = WIO.Retry.Mode.Stateless[Ctx, In](_ =>
+          (_, err, _, now) => {
+            IO.pure(onError.lift(err) match {
+              case Some(backoff) => WIO.Retry.Stateless.Result.ScheduleWakeup(now.plus(backoff))
+              case None          => WIO.Retry.Stateless.Result.Ignore
+            })
+          },
+        )
         WIO.Retry(base, mode)
       }
 
@@ -43,10 +46,14 @@ object RetryBuilder {
 
       type OnErrorInput = (stepInput: In, error: Throwable, workflowState: WCState[Ctx], retryState: Option[RetryState])
 
-      def onError[Event <: WCEvent[Ctx]](onError: OnErrorInput => IO[WIO.Retry.Stateful.Result[Event]])(using ClassTag[Event]): Step1[Event] =
-        new Step1[Event](onError)
+      def onError[Event <: WCEvent[Ctx]](onError: WIOContext[WCState[Ctx]] ?=> OnErrorInput => IO[WIO.Retry.Stateful.Result[Event]])(using
+          ClassTag[Event],
+      ): Step1[Event] =
+        new Step1[Event](ctx => onError(using ctx))
 
-      class Step1[Event <: WCEvent[Ctx]](onError: OnErrorInput => IO[WIO.Retry.Stateful.Result[Event]])(using evtCt: ClassTag[Event]) {
+      class Step1[Event <: WCEvent[Ctx]](onError: WIOContext[WCState[Ctx]] => OnErrorInput => IO[WIO.Retry.Stateful.Result[Event]])(using
+          evtCt: ClassTag[Event],
+      ) {
 
         type EventHandlerInput = (stepInput: In, event: Event, workflowState: WCState[Ctx], retryState: Option[RetryState])
 

--- a/workflows4s-core/src/main/scala/workflows4s/wio/builders/RunIOBuilder.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/builders/RunIOBuilder.scala
@@ -6,7 +6,7 @@ import cats.effect.IO
 import cats.implicits.catsSyntaxEitherId
 import workflows4s.wio.internal.EventHandler
 import workflows4s.wio.model.ModelUtils
-import workflows4s.wio.{ErrorMeta, WCEvent, WCState, WIO, WorkflowContext}
+import workflows4s.wio.{ErrorMeta, WCEvent, WCState, WIO, WIOContext, WorkflowContext}
 
 object RunIOBuilder {
 
@@ -15,11 +15,11 @@ object RunIOBuilder {
     def runIO[Input] = new RunIOBuilderStep1[Input]
 
     class RunIOBuilderStep1[Input] {
-      def apply[Evt <: WCEvent[Ctx]: ClassTag](f: Input => IO[Evt]): Step2[Input, Evt] = {
-        new Step2[Input, Evt](f)
+      def apply[Evt <: WCEvent[Ctx]: ClassTag](f: WIOContext[WCState[Ctx]] ?=> Input => IO[Evt]): Step2[Input, Evt] = {
+        new Step2[Input, Evt](ctx => f(using ctx))
       }
 
-      class Step2[In, Evt <: WCEvent[Ctx]: ClassTag](getIO: In => IO[Evt]) {
+      class Step2[In, Evt <: WCEvent[Ctx]: ClassTag](getIO: WIOContext[WCState[Ctx]] => In => IO[Evt]) {
         def handleEvent[Out <: WCState[Ctx]](f: (In, Evt) => Out): Step3[Out, Nothing] =
           Step3((s, e: Evt) => f(s, e).asRight, ErrorMeta.noError)
 

--- a/workflows4s-core/src/main/scala/workflows4s/wio/builders/WIOBuilderMethods.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/builders/WIOBuilderMethods.scala
@@ -11,7 +11,7 @@ trait WIOBuilderMethods[Ctx <: WorkflowContext] {
 
   def end: WIO[Any, Nothing, Nothing, Ctx] = WIO.End[Ctx]()
 
-  def getState[St <: WCState[Ctx]]: WIO[St, Nothing, St, Ctx] = WIO.Pure(s => s.asRight, WIO.Pure.Meta(NoError(), None))
+  def getState[St <: WCState[Ctx]]: WIO[St, Nothing, St, Ctx] = WIO.Pure(_ => s => s.asRight, WIO.Pure.Meta(NoError(), None))
 
   def embed[In, Err, Out <: WCState[InnerCtx], InnerCtx <: WorkflowContext, OS[_ <: WCState[InnerCtx]] <: WCState[Ctx]](
       wio: WIO[In, Err, Out, InnerCtx],

--- a/workflows4s-core/src/main/scala/workflows4s/wio/internal/ProceedEvaluator.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/internal/ProceedEvaluator.scala
@@ -1,6 +1,7 @@
 package workflows4s.wio.internal
 
 import cats.syntax.all.*
+import workflows4s.runtime.WorkflowInstanceId
 import workflows4s.wio.*
 
 // For the given workflow tries to move it to next step if possible without executing any side-effecting comptations.
@@ -11,8 +12,9 @@ object ProceedEvaluator {
   def proceed[Ctx <: WorkflowContext](
       wio: WIO[Any, Nothing, WCState[Ctx], Ctx],
       state: WCState[Ctx],
+      instanceId: WorkflowInstanceId,
   ): Response[Ctx] = {
-    val visitor: ProceedVisitor[Ctx, Any, Nothing, WCState[Ctx]] = new ProceedVisitor(wio, state, state, 0)
+    val visitor: ProceedVisitor[Ctx, Any, Nothing, WCState[Ctx]] = new ProceedVisitor(wio, state, state, 0, instanceId)
     Response(visitor.run.map(_.wio))
   }
 
@@ -23,6 +25,7 @@ object ProceedEvaluator {
       input: In,
       lastSeenState: WCState[Ctx],
       index: Int,
+      instanceId: WorkflowInstanceId,
   ) extends ProceedingVisitor[Ctx, In, Err, Out](wio, input, lastSeenState, index) {
 
     def onSignal[Sig, Evt, Resp](wio: WIO.HandleSignal[Ctx, In, Out, Err, Sig, Resp, Evt]): Result = None
@@ -31,14 +34,16 @@ object ProceedEvaluator {
     def onAwaitingTime(wio: WIO.AwaitingTime[Ctx, In, Err, Out]): Result                           = None
     override def onRecovery[Evt](wio: WIO.Recovery[Ctx, In, Err, Out, Evt]): Result                = None
 
-    def onPure(wio: WIO.Pure[Ctx, In, Err, Out]): Result =
-      WFExecution.complete(wio, wio.value(input), input, index).some
+    def onPure(wio: WIO.Pure[Ctx, In, Err, Out]): Result = {
+      val ctx = WIOContext(instanceId, lastSeenState)
+      WFExecution.complete(wio, wio.value(ctx)(input), input, index).some
+    }
 
     def onEmbedded[InnerCtx <: WorkflowContext, InnerOut <: WCState[InnerCtx], MappingOutput[_ <: WCState[InnerCtx]] <: WCState[Ctx]](
         wio: WIO.Embedded[Ctx, In, Err, InnerCtx, InnerOut, MappingOutput],
     ): Result = {
       val newState: WCState[InnerCtx] = wio.embedding.unconvertStateUnsafe(lastSeenState)
-      new ProceedVisitor(wio.inner, input, newState, index).run
+      new ProceedVisitor(wio.inner, input, newState, index, instanceId).run
         .map(convertEmbeddingResult2(wio, _, input))
     }
 
@@ -53,7 +58,7 @@ object ProceedEvaluator {
       def completeEmpty    = WFExecution.complete(wio, Right(wio.buildOutput(input, Map())), input, maxIndex + 1)
       def updateChild      = {
         val updatedElem = state.toList.collectFirstSome((elemId, elemWio) => {
-          new ProceedVisitor(elemWio, input, wio.initialElemState(), maxIndex).run.tupleLeft(elemId)
+          new ProceedVisitor(elemWio, input, wio.initialElemState(), maxIndex, instanceId).run.tupleLeft(elemId)
         })
         updatedElem.map(newWf => convertForEachResult(wio, newWf._2, input, newWf._1))
       }
@@ -69,7 +74,7 @@ object ProceedEvaluator {
         index: Int,
     ): Option[WFExecution[Ctx, I1, E1, O1]] = {
       val nextIndex = Math.max(index, this.index) // handle parallel case
-      new ProceedVisitor(wio, in, state, nextIndex).run
+      new ProceedVisitor(wio, in, state, nextIndex, instanceId).run
     }
 
   }

--- a/workflows4s-core/src/main/scala/workflows4s/wio/internal/RunIOEvaluator.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/internal/RunIOEvaluator.scala
@@ -3,6 +3,7 @@ package workflows4s.wio.internal
 import cats.data.Ior
 import cats.effect.IO
 import cats.syntax.all.*
+import workflows4s.runtime.WorkflowInstanceId
 import workflows4s.wio.*
 import workflows4s.wio.WIO.HandleInterruption.InterruptionStatus
 import workflows4s.wio.WIO.Retry.Mode
@@ -15,8 +16,9 @@ object RunIOEvaluator {
       wio: WIO[StIn, Nothing, WCState[Ctx], Ctx],
       state: StIn,
       now: Instant,
+      instanceId: WorkflowInstanceId,
   ): WakeupResult[WCEvent[Ctx]] = {
-    val visitor = new RunIOVisitor(wio, state, state, now)
+    val visitor = new RunIOVisitor(wio, state, state, now, instanceId)
     WakeupResult.fromRaw(visitor.run)
   }
 
@@ -25,8 +27,11 @@ object RunIOEvaluator {
       input: In,
       lastSeenState: WCState[Ctx],
       now: Instant,
+      instanceId: WorkflowInstanceId,
   ) extends Visitor[Ctx, In, Err, Out](wio) {
     override type Result = Option[IO[Ior[Instant, WCEvent[Ctx]]]]
+
+    private lazy val ctx: WIOContext[WCState[Ctx]] = WIOContext(instanceId, lastSeenState)
 
     def onExecuted[In1](wio: WIO.Executed[Ctx, Err, Out, In1]): Result                             = None
     def onSignal[Sig, Evt, Resp](wio: WIO.HandleSignal[Ctx, In, Out, Err, Sig, Resp, Evt]): Result = None
@@ -35,7 +40,8 @@ object RunIOEvaluator {
     def onDiscarded[In](wio: WIO.Discarded[Ctx, In]): Result                                       = None
     override def onRecovery[Evt](wio: WIO.Recovery[Ctx, In, Err, Out, Evt]): Result                = None
 
-    def onRunIO[Evt](wio: WIO.RunIO[Ctx, In, Err, Out, Evt]): Result = wio.buildIO(input).map(wio.evtHandler.convert).map(_.rightIor).some
+    def onRunIO[Evt](wio: WIO.RunIO[Ctx, In, Err, Out, Evt]): Result =
+      wio.buildIO(ctx)(input).map(wio.evtHandler.convert).map(_.rightIor).some
 
     def onFlatMap[Out1 <: WCState[Ctx], Err1 <: Err](wio: WIO.FlatMap[Ctx, Err1, Err, Out1, Out, In]): Result          = recurse(wio.base, input)
     def onTransform[In1, Out1 <: State, Err1](wio: WIO.Transform[Ctx, In1, Err1, Out1, In, Out, Err]): Result          =
@@ -78,7 +84,7 @@ object RunIOEvaluator {
         wio: WIO.Embedded[Ctx, In, Err, InnerCtx, InnerOut, MappingOutput],
     ): Result = {
       val newState: WCState[InnerCtx] = wio.embedding.unconvertStateUnsafe(lastSeenState)
-      new RunIOVisitor(wio.inner, input, newState, now).run
+      new RunIOVisitor(wio.inner, input, newState, now, instanceId).run
         .map(_.map(_.map(wio.embedding.convertEvent)))
     }
 
@@ -117,7 +123,7 @@ object RunIOEvaluator {
         case Some(executedBase) =>
           executedBase.output match {
             case Left(_)        => None
-            case Right(baseOut) => wio.genEvent(input, baseOut).map(wio.eventHandler.convert).map(_.rightIor).some
+            case Right(baseOut) => wio.genEvent(ctx)(input, baseOut).map(wio.eventHandler.convert).map(_.rightIor).some
           }
         case None               => recurse(wio.base, input)
       }
@@ -128,13 +134,13 @@ object RunIOEvaluator {
         _.handleErrorWith(err =>
           wio.mode match {
             case Mode.Stateless(errorHandler)               =>
-              errorHandler(input, err, lastSeenState, now)
+              errorHandler(ctx)(input, err, lastSeenState, now)
                 .flatMap({
                   case WIO.Retry.Stateless.Result.Ignore             => IO.raiseError(err)
                   case WIO.Retry.Stateless.Result.ScheduleWakeup(at) => IO.pure(at.leftIor)
                 })
             case Mode.Stateful(errorHandler, _, retryState) =>
-              errorHandler(input, err, lastSeenState, retryState).flatMap({
+              errorHandler(ctx)(input, err, lastSeenState, retryState).flatMap({
                 case WIO.Retry.Stateful.Result.Ignore                    => IO.raiseError(err)
                 case WIO.Retry.Stateful.Result.ScheduleWakeup(at, event) =>
                   IO.pure(event match {
@@ -153,12 +159,12 @@ object RunIOEvaluator {
     ): Result = {
       val state = wio.state(input)
       state.toList
-        .collectFirstSome((elemId, elemWio) => new RunIOVisitor(elemWio, input, wio.initialElemState(), now).run.tupleLeft(elemId))
+        .collectFirstSome((elemId, elemWio) => new RunIOVisitor(elemWio, input, wio.initialElemState(), now, instanceId).run.tupleLeft(elemId))
         .map { case (elemId, io) => io.map(_.map(wio.eventEmbedding.convertEvent(elemId, _))) }
     }
 
     private def recurse[I1, E1, O1 <: WCState[Ctx]](wio: WIO[I1, E1, O1, Ctx], s: I1): Option[IO[Ior[Instant, WCEvent[Ctx]]]] =
-      new RunIOVisitor(wio, s, lastSeenState, now).run
+      new RunIOVisitor(wio, s, lastSeenState, now, instanceId).run
 
   }
 

--- a/workflows4s-core/src/main/scala/workflows4s/wio/internal/SignalEvaluator.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/internal/SignalEvaluator.scala
@@ -1,6 +1,7 @@
 package workflows4s.wio.internal
 
 import com.typesafe.scalalogging.StrictLogging
+import workflows4s.runtime.WorkflowInstanceId
 import workflows4s.wio.*
 import workflows4s.wio.WIO.HandleInterruption.InterruptionStatus
 
@@ -54,9 +55,10 @@ object SignalEvaluator {
       req: Req,
       wio: WIO[In, Nothing, Out, Ctx],
       state: In,
+      instanceId: WorkflowInstanceId,
   ): SignalResult[WCEvent[Ctx], Resp] = {
     val matches = new SignalVisitor[Ctx, In, Nothing, Out](wio).run
-      .flatMap(_.tryProduce(signalDef, req, state, state))
+      .flatMap(_.tryProduce(signalDef, req, state, state, instanceId))
 
     // Fresh signals come before redeliverable ones due to traversal order
     matches.headOption.getOrElse(SignalResult.UnexpectedSignal)
@@ -141,13 +143,14 @@ object SignalEvaluator {
         request: Req1,
         input: TopIn,
         topState: TopState,
+        instanceId: WorkflowInstanceId,
     ): Option[SignalResult[OutEvent, Resp1]] =
       for {
-        _           <- Option.when(outerSignalDef.id == signalDef.id)(())
-        innerReq    <- unwrapRequest(request, input, topState)
-        typedReq     = verifyRequestType(innerReq)
-        (localIn, _) = transform(input, topState)
-      } yield produceResult(typedReq, localIn, outerSignalDef)
+        _                    <- Option.when(outerSignalDef.id == signalDef.id)(())
+        innerReq             <- unwrapRequest(request, input, topState)
+        typedReq              = verifyRequestType(innerReq)
+        (localIn, localState) = transform(input, topState)
+      } yield produceResult(typedReq, localIn, outerSignalDef, instanceId, localState)
 
     private def unwrapRequest(request: Any, input: TopIn, state: TopState): Option[Any] =
       routing match {
@@ -160,10 +163,16 @@ object SignalEvaluator {
         throw new Exception(s"Request type mismatch for signal ${node.sigDef.name}. Expected: ${node.sigDef.reqCt}, got: $request")
       }
 
-    private def produceResult[Resp1](typedReq: Req, localInput: LocalIn, outerSignalDef: SignalDef[?, Resp1]): SignalResult[OutEvent, Resp1] =
+    private def produceResult[Resp1](
+        typedReq: Req,
+        localInput: LocalIn,
+        outerSignalDef: SignalDef[?, Resp1],
+        instanceId: WorkflowInstanceId,
+        localState: WCState[LocalCtx],
+    ): SignalResult[OutEvent, Resp1] =
       storedEvent match {
         case Some(evt) => redeliverFromStoredEvent(typedReq, localInput, evt, outerSignalDef)
-        case None      => handleFreshSignal(typedReq, localInput, outerSignalDef)
+        case None      => handleFreshSignal(typedReq, localInput, outerSignalDef, instanceId, localState)
       }
 
     private def redeliverFromStoredEvent[Resp1](
@@ -183,8 +192,11 @@ object SignalEvaluator {
         typedReq: Req,
         localInput: LocalIn,
         outerSignalDef: SignalDef[?, Resp1],
+        instanceId: WorkflowInstanceId,
+        localState: WCState[LocalCtx],
     ): SignalResult[OutEvent, Resp1] = {
-      SignalResult.Processed(node.sigHandler.handle(localInput, typedReq).map { evt =>
+      val ctx = WIOContext[WCState[LocalCtx]](instanceId, localState)
+      SignalResult.Processed(node.sigHandler.handle(ctx)(localInput, typedReq).map { evt =>
         val convertedEvent = eventTransform(node.evtHandler.convert(evt))
         val response       = node.responseProducer(localInput, evt, typedReq)
         SignalResult.ProcessingResult(convertedEvent, extractTypedResponse(outerSignalDef, response))

--- a/workflows4s-core/src/main/scala/workflows4s/wio/internal/utils.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/internal/utils.scala
@@ -1,6 +1,7 @@
 package workflows4s.wio.internal
 
 import cats.effect.IO
+import workflows4s.wio.WIOContext
 
 import scala.reflect.ClassTag
 import scala.util.chaining.scalaUtilChainingOps
@@ -53,6 +54,6 @@ object EventHandler {
     typed(convert0, handle0, ct)
 }
 
-case class SignalHandler[-Sig, +Evt, -In](handle: (In, Sig) => IO[Evt]) {
-  def map[E1](f: Evt => E1): SignalHandler[Sig, E1, In] = SignalHandler((in, sig) => handle(in, sig).map(f))
+case class SignalHandler[-Sig, +Evt, -In, State](handle: WIOContext[State] => (In, Sig) => IO[Evt]) {
+  def map[E1](f: Evt => E1): SignalHandler[Sig, E1, In, State] = SignalHandler(ctx => (in, sig) => handle(ctx)(in, sig).map(f))
 }

--- a/workflows4s-core/src/test/scala/workflows4s/wio/WIOCheckpointTest.scala
+++ b/workflows4s-core/src/test/scala/workflows4s/wio/WIOCheckpointTest.scala
@@ -1,7 +1,9 @@
 package workflows4s.wio
 
+import cats.effect.IO
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+import workflows4s.runtime.WorkflowInstanceId
 import workflows4s.testing.TestUtils
 
 class WIOCheckpointTest extends AnyFreeSpec with Matchers {
@@ -107,6 +109,30 @@ class WIOCheckpointTest extends AnyFreeSpec with Matchers {
       wf1.wakeup()
       assert(wf1.queryState().executed == List())
       assert(wf1.queryState().errors == List(error))
+    }
+    "WIOContext propagation through checkpoint" in {
+      var capturedId: Option[WorkflowInstanceId] = None
+      case class RunIODone(stepId: StepId)      extends TestCtx2.Event
+      case class MyCheckpoint(state: TestState) extends TestCtx2.Event
+
+      val stepId = StepId.random("ckp-ctx")
+      val inner  = WIO
+        .runIO[TestState] { _ =>
+          capturedId = Some(WIOContext.instanceId)
+          IO.pure(RunIODone(stepId))
+        }
+        .handleEvent((st, evt) => st.addExecuted(evt.stepId))
+        .done
+
+      val wio     = inner.checkpointed(
+        (_, state) => MyCheckpoint(state),
+        (_, ckp) => ckp.state,
+      )
+      val (_, wf) = TestUtils.createInstance2(wio)
+      wf.wakeup()
+
+      assert(capturedId.isDefined)
+      assert(capturedId.get.templateId == "test")
     }
   }
 

--- a/workflows4s-core/src/test/scala/workflows4s/wio/WIOHandleInterruptionTest.scala
+++ b/workflows4s-core/src/test/scala/workflows4s/wio/WIOHandleInterruptionTest.scala
@@ -1,8 +1,10 @@
 package workflows4s.wio
 
+import cats.effect.IO
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{EitherValues, OptionValues}
+import workflows4s.runtime.WorkflowInstanceId
 import workflows4s.testing.TestUtils
 
 import scala.concurrent.duration.DurationInt
@@ -187,6 +189,38 @@ class WIOHandleInterruptionTest extends AnyFreeSpec with Matchers with OptionVal
           capturedExecutedList === List(signalFirstStepId, signalBase1StepId),
           "Interruption handler should see state changes from base, not just from parent AndThen",
         )
+      }
+    }
+
+    "WIOContext propagation" - {
+
+      "interruption signal handler receives instance id" in {
+        import TestCtx2.*
+
+        var capturedId: Option[WorkflowInstanceId] = None
+        val interruptSignalDef                     = SignalDef[Int, Int](id = "ctx-interrupt")
+        case class InterruptEvt(req: Int) extends TestCtx2.Event
+        val interruptStepId = StepId.random("interrupt-ctx")
+
+        val interruptHandler = WIO
+          .handleSignal(interruptSignalDef)
+          .using[TestState]
+          .withSideEffects { (_, req) =>
+            capturedId = Some(WIOContext.instanceId)
+            IO.pure(InterruptEvt(req))
+          }
+          .handleEvent((st, _) => st.addExecuted(interruptStepId))
+          .produceResponse((_, evt, _) => evt.req)
+          .done
+
+        val (signalB, _, handleSignalB) = TestUtils.signal
+        val wf                          = handleSignalB.interruptWith(interruptHandler.toInterruption)
+        val (_, instance)               = TestUtils.createInstance2(wf)
+
+        instance.deliverSignal(interruptSignalDef, 42).value
+
+        assert(capturedId.isDefined)
+        assert(capturedId.get.templateId == "test")
       }
     }
 

--- a/workflows4s-core/src/test/scala/workflows4s/wio/WIOHandleSignalTest.scala
+++ b/workflows4s-core/src/test/scala/workflows4s/wio/WIOHandleSignalTest.scala
@@ -6,6 +6,7 @@ import cats.implicits.catsSyntaxOptionId
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.EitherValues
+import workflows4s.runtime.WorkflowInstanceId
 import workflows4s.testing.TestUtils
 import workflows4s.wio.WIO.HandleSignal
 
@@ -265,6 +266,32 @@ class WIOHandleSignalTest extends AnyFreeSpec with Matchers with EitherValues {
         // Redelivery with different request - response producer sees both values
         val response3 = instance.deliverSignal(signalDef, 99).value
         assert(response3 == "original=42, current=99")
+      }
+    }
+
+    "WIOContext propagation" - {
+
+      "receives instance id" in {
+        val signalDef                              = SignalDef[Int, String]()
+        var capturedId: Option[WorkflowInstanceId] = None
+        val wf                                     = WIO
+          .handleSignal(signalDef)
+          .using[String]
+          .withSideEffects { (input, req) =>
+            capturedId = Some(WIOContext.instanceId)
+            IO.pure(s"sig($input,$req)")
+          }
+          .handleEvent((_, evt) => evt.value)
+          .produceResponse((_, _, _) => "resp")
+          .done
+          .toWorkflow("initial")
+
+        wf.handleSignal(signalDef)(42) match {
+          case SignalResult.Processed(io) => io.unsafeRunSync()
+          case other                      => fail(s"Expected Processed, got $other")
+        }
+
+        assert(capturedId.contains(WorkflowInstanceId("test", "test")))
       }
     }
 

--- a/workflows4s-core/src/test/scala/workflows4s/wio/WIOPureTest.scala
+++ b/workflows4s-core/src/test/scala/workflows4s/wio/WIOPureTest.scala
@@ -97,6 +97,39 @@ class WIOPureTest extends AnyFreeSpec with Matchers {
         assert(meta.error == ErrorMeta.Present("custom"))
       }
     }
+
+    "WIOContext propagation" - {
+
+      "receives instance id" in {
+        import TestCtx2.*
+        val wio           = WIO.pure
+          .makeFrom[TestState]
+          .value { _ =>
+            val id = WIOContext.instanceId
+            TestState.empty.addExecuted(StepId.random(id.templateId))
+          }
+          .done
+        val (_, instance) = TestUtils.createInstance2(wio)
+
+        val state = instance.queryState()
+        assert(state.executed.size == 1)
+        assert(state.executed.head.startsWith("test"))
+      }
+
+      "receives current state" in {
+        import TestCtx2.*
+        val wio           = WIO.pure
+          .makeFrom[TestState]
+          .value { _ =>
+            val st = WIOContext.currentState[TestState]
+            st.addExecuted(StepId.random("pure-ctx"))
+          }
+          .done
+        val (_, instance) = TestUtils.createInstance2(wio)
+
+        assert(instance.queryState().executed.size == 1)
+      }
+    }
   }
 
 }

--- a/workflows4s-core/src/test/scala/workflows4s/wio/WIORetryTest.scala
+++ b/workflows4s-core/src/test/scala/workflows4s/wio/WIORetryTest.scala
@@ -5,6 +5,7 @@ import cats.implicits.catsSyntaxOptionId
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{EitherValues, OptionValues}
+import workflows4s.runtime.WorkflowInstanceId
 import workflows4s.testing.{TestRuntime, TestUtils}
 
 import java.time.{Duration, Instant}
@@ -115,6 +116,47 @@ class WIORetryTest extends AnyFreeSpec with Matchers with OptionValues with Eith
         // wakeup didnt throw but woke up
         instance.wakeup()
         assert(instance.queryState() == TestState(List(stepId)))
+      }
+    }
+
+    "WIOContext propagation" - {
+
+      "stateless error handler receives instance id" in new Fixture {
+        var capturedId: Option[WorkflowInstanceId] = None
+
+        val retryingWIO = failingWIO.retry.statelessly.wakeupAt { (_, _, _) =>
+          capturedId = Some(WIOContext.instanceId)
+          IO(Some(Instant.now().plus(Duration.ofSeconds(1))))
+        }
+        val instance    = runtime.createInstance(retryingWIO)
+
+        instance.wakeup()
+
+        assert(capturedId.isDefined)
+        assert(capturedId.get.templateId == "test")
+      }
+
+      "stateful error handler receives instance id" in new Fixture {
+        var capturedId: Option[WorkflowInstanceId] = None
+        case class RetryEvent(inc: Int) extends TestCtx2.Event
+
+        val retryingWIO = failingWIO.retry
+          .usingState[Int]
+          .onError[RetryEvent] { _ =>
+            capturedId = Some(WIOContext.instanceId)
+            IO(WIO.Retry.Stateful.Result.ScheduleWakeup(Instant.now().plus(Duration.ofSeconds(1)), RetryEvent(1).some))
+          }
+          .handleEventsWith((_, _, _, retryState) => {
+            val newState = retryState.getOrElse(0) + 1
+            if newState < 2 then Left(newState)
+            else Right(Right(TestState.empty.addError("recovered")))
+          })
+
+        val instance = runtime.createInstance(retryingWIO)
+        instance.wakeup()
+
+        assert(capturedId.isDefined)
+        assert(capturedId.get.templateId == "test")
       }
     }
   }

--- a/workflows4s-core/src/test/scala/workflows4s/wio/WIORunIOTest.scala
+++ b/workflows4s-core/src/test/scala/workflows4s/wio/WIORunIOTest.scala
@@ -5,6 +5,7 @@ import cats.effect.unsafe.implicits.global
 import org.scalatest.{EitherValues, OptionValues}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+import workflows4s.runtime.WorkflowInstanceId
 import workflows4s.wio.WIO.RunIO
 import workflows4s.wio.internal.SignalResult
 
@@ -113,6 +114,41 @@ class WIORunIOTest extends AnyFreeSpec, Matchers, EitherValues, OptionValues {
 
         val meta = wio.extractMeta
         assert(meta.error == ErrorMeta.Present("XXX"))
+      }
+    }
+
+    "WIOContext propagation" - {
+
+      "receives instance id" in {
+        var capturedId: Option[WorkflowInstanceId] = None
+        val wf                                     = WIO
+          .runIO[String] { input =>
+            capturedId = Some(WIOContext.instanceId)
+            IO.pure(s"done($input)")
+          }
+          .handleEvent((_, evt) => evt.value)
+          .done
+          .toWorkflow("initial")
+
+        wf.proceed(Instant.now).toRaw.value.unsafeRunSync()
+
+        capturedId.value shouldBe WorkflowInstanceId("test", "test")
+      }
+
+      "receives current state" in {
+        var capturedState: Option[String] = None
+        val wf                            = WIO
+          .runIO[String] { input =>
+            capturedState = Some(WIOContext.currentState[String])
+            IO.pure(s"done($input)")
+          }
+          .handleEvent((_, evt) => evt.value)
+          .done
+          .toWorkflow("myState")
+
+        wf.proceed(Instant.now).toRaw.value.unsafeRunSync()
+
+        capturedState.value shouldBe "myState"
       }
     }
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow handlers and computations now have access to runtime context including the workflow instance identifier and current workflow state during execution.
  * Signal handlers, IO operations, pure computations, and retry handlers can leverage this context for enhanced logging, debugging, and state-dependent logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->