### PR TITLE
fix: treat a loop with only an unstarted body as not started

### DIFF
--- a/workflows4s-core/src/main/scala/workflows4s/RenderUtils.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/RenderUtils.scala
@@ -16,7 +16,7 @@ private[workflows4s] object RenderUtils {
     case WIOExecutionProgress.HandleError(base, handler, _, _)     => hasStarted(base) || hasStarted(handler)
     case WIOExecutionProgress.End(result)                          => result.isDefined
     case WIOExecutionProgress.Pure(_, result)                      => result.isDefined
-    case WIOExecutionProgress.Loop(_, _, _, history)               => history.nonEmpty
+    case WIOExecutionProgress.Loop(_, _, _, history)               => history.exists(hasStarted)
     case WIOExecutionProgress.Fork(_, _, selected)                 => selected.isDefined
     case WIOExecutionProgress.Interruptible(base, trigger, _, _)   => hasStarted(base) || hasStarted(trigger)
     case WIOExecutionProgress.Timer(_, result)                     => result.isDefined

--- a/workflows4s-core/src/test/scala/workflows4s/RenderUtilsTest.scala
+++ b/workflows4s-core/src/test/scala/workflows4s/RenderUtilsTest.scala
@@ -1,0 +1,25 @@
+package workflows4s
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import workflows4s.wio.model.WIOExecutionProgress.ExecutedResult
+import workflows4s.wio.model.{WIOExecutionProgress, WIOMeta, WIOModel}
+
+class RenderUtilsTest extends AnyFreeSpec with Matchers {
+
+  private val loopMeta = WIOMeta.Loop(None, None, None)
+
+  private def loop(history: Seq[WIOExecutionProgress[String]]): WIOExecutionProgress.Loop[String] =
+    WIOExecutionProgress.Loop(WIOModel.End, None, loopMeta, history)
+
+  "RenderUtils.hasStarted" - {
+    "reports a loop as not started when its history only holds the not-yet-executed body" in {
+      RenderUtils.hasStarted(loop(Seq(WIOExecutionProgress.End(None)))) shouldBe false
+    }
+
+    "reports a loop as started once a history entry has executed" in {
+      val executed = WIOExecutionProgress.End(Some(ExecutedResult(Right("done"), 0)))
+      RenderUtils.hasStarted(loop(Seq(executed))) shouldBe true
+    }
+  }
+}

--- a/workflows4s-example/src/test/resources/docs/draft-loop/diagram.mermaid
+++ b/workflows4s-example/src/test/resources/docs/draft-loop/diagram.mermaid
@@ -1,5 +1,5 @@
 flowchart TD
-node0:::executed@{ shape: circle, label: "Start"}
+node0@{ shape: circle, label: "Start"}
 node1["Process Item"]
 node0 --> node1
 node2@{ shape: stadium, label: "fa:fa-clock Wait before retry (1m)"}
@@ -11,4 +11,3 @@ node3 -->|"No"| node4
 node4 --> node1
 node5@{ shape: circle, label: "End"}
 node3 -->|"Yes"| node5
-classDef executed fill:#0e0

--- a/workflows4s-example/src/test/resources/docs/loop/diagram.mermaid
+++ b/workflows4s-example/src/test/resources/docs/loop/diagram.mermaid
@@ -1,5 +1,5 @@
 flowchart TD
-node0:::executed@{ shape: circle, label: "Start"}
+node0@{ shape: circle, label: "Start"}
 node1["Step1"]
 node0 --> node1
 node2@{ shape: hex, label: "Is everything done?"}
@@ -9,4 +9,3 @@ node2 -->|"No"| node3
 node3 --> node1
 node4@{ shape: circle, label: "End"}
 node2 -->|"Yes!"| node4
-classDef executed fill:#0e0

--- a/workflows4s-example/src/test/resources/docs/simple-loop/diagram.mermaid
+++ b/workflows4s-example/src/test/resources/docs/simple-loop/diagram.mermaid
@@ -1,5 +1,5 @@
 flowchart TD
-node0:::executed@{ shape: circle, label: "Start"}
+node0@{ shape: circle, label: "Start"}
 node1["Step1"]
 node0 --> node1
 node2@{ shape: hex, label: " "}
@@ -7,4 +7,3 @@ node1 --> node2
 node2 --> node1
 node3@{ shape: circle, label: "End"}
 node2 --> node3
-classDef executed fill:#0e0


### PR DESCRIPTION
Closes #259:

`RenderUtils.hasStarted` reported a loop as started whenever its `history` was non-empty,
but `ExecutionProgressEvaluator.onLoop` seeds `history` with the not-yet-executed body, so a
loop that begins a workflow rendered with the "executed" class before any iteration ran.
This recurses into the history entries instead, matching the workaround `MermaidRenderer`
already applies on the loop node itself, so the `Start` node and other consumers get the
right answer.

Added `RenderUtilsTest` for the unstarted-body and started-history cases, and regenerated the
`simple-loop`, `loop` and `draft-loop` example diagrams, which previously showed the Start node
as executed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected loop execution "started" detection so individual history entries are evaluated for started status.

* **Tests**
  * Added tests covering loop execution progress with different history states to prevent regressions.

* **Documentation**
  * Updated example diagrams to remove outdated "executed" styling for clearer visual examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->