### PR TITLE
fix: keep the last step of a 3-element interruption sequence

### DIFF
--- a/workflows4s-core/src/main/scala/workflows4s/wio/internal/ExecutionProgressEvaluator.scala
+++ b/workflows4s-core/src/main/scala/workflows4s/wio/internal/ExecutionProgressEvaluator.scala
@@ -194,7 +194,7 @@ object ExecutionProgressEvaluator {
             rest match {
               case Some(value) => WIOExecutionProgress.Sequence(steps.toList.updated(0, value)).some
               case None        =>
-                if steps.size > 3 then WIOExecutionProgress.Sequence(steps.tail).some
+                if steps.size > 2 then WIOExecutionProgress.Sequence(steps.tail).some
                 else steps(1).some
             },
           ),

--- a/workflows4s-core/src/test/scala/workflows4s/wio/internal/ExtractFirstInterruptionTest.scala
+++ b/workflows4s-core/src/test/scala/workflows4s/wio/internal/ExtractFirstInterruptionTest.scala
@@ -1,0 +1,24 @@
+package workflows4s.wio.internal
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import workflows4s.wio.model.{WIOExecutionProgress, WIOMeta}
+
+class ExtractFirstInterruptionTest extends AnyFreeSpec with Matchers {
+
+  private def signal(name: String): WIOExecutionProgress.HandleSignal[Int] =
+    WIOExecutionProgress.HandleSignal(WIOMeta.HandleSignal(name, None, None), None)
+
+  private def pure(name: String): WIOExecutionProgress.Pure[Int] =
+    WIOExecutionProgress.Pure(WIOMeta.Pure(Some(name), None), None)
+
+  "extractFirstInterruption" - {
+    "should keep every step after the interruption in a 3-element sequence" in {
+      val flow = WIOExecutionProgress.Sequence(Seq(signal("cancel"), pure("cleanup"), pure("notify")))
+
+      val Some((_, Some(rest))) = ExecutionProgressEvaluator.extractFirstInterruption(flow): @unchecked
+
+      rest shouldBe WIOExecutionProgress.Sequence(Seq(pure("cleanup"), pure("notify")))
+    }
+  }
+}


### PR DESCRIPTION
Closes #258.

`extractFirstInterruption` guarded the "rewrap the remaining steps in a `Sequence`" branch with `steps.size > 3`, so a sequence of exactly three steps fell into the `else` and returned only `steps(1)`, dropping `steps(2)`. The threshold should be `steps.size > 2`: once the head interruption is consumed the rest is `steps.tail`, which only collapses to a single node when the tail has one element. Added a regression test that renders a three-step interruption path and checks both trailing steps survive.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved workflow interruption handling to correctly preserve remaining steps during interruption extraction.

* **Tests**
  * Added test coverage for interruption extraction in multi-step workflow sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->