### PR TITLE
Add support for wakeup claim tracking in PostgresWorkflowRegistry

### DIFF
--- a/workflows4s-doobie/src/main/resources/schema/postgres-workflow-registry-schema.sql
+++ b/workflows4s-doobie/src/main/resources/schema/postgres-workflow-registry-schema.sql
@@ -1,15 +1,20 @@
 -- doc_start
 CREATE TABLE if not exists workflow_registry
 (
-    template_id TEXT        NOT NULL,
-    instance_id TEXT        NOT NULL,
-    status      TEXT        NOT NULL CHECK (status IN ('Running', 'Awaiting', 'Finished')),
-    created_at  TIMESTAMPTZ NOT NULL,
-    updated_at  TIMESTAMPTZ NOT NULL,
-    wakeup_at   TIMESTAMPTZ NULL,
-    tags        JSONB       NOT NULL DEFAULT '{}'::JSONB,
+    template_id       TEXT        NOT NULL,
+    instance_id       TEXT        NOT NULL,
+    status            TEXT        NOT NULL CHECK (status IN ('Running', 'Awaiting', 'Finished')),
+    created_at        TIMESTAMPTZ NOT NULL,
+    updated_at        TIMESTAMPTZ NOT NULL,
+    wakeup_at         TIMESTAMPTZ NULL,
+    wakeup_claimed_at TIMESTAMPTZ NULL,
+    tags              JSONB       NOT NULL DEFAULT '{}'::JSONB,
     primary key (template_id, instance_id)
 );
+
+-- upgrade path for tables created before wakeup claims were introduced
+ALTER TABLE workflow_registry
+    ADD COLUMN IF NOT EXISTS wakeup_claimed_at TIMESTAMPTZ NULL;
 
 CREATE INDEX if not exists idx_workflow_registry_wakeup
     ON workflow_registry (wakeup_at)

--- a/workflows4s-doobie/src/main/scala/workflows4s/doobie/postgres/PostgresWorkflowRegistry.scala
+++ b/workflows4s-doobie/src/main/scala/workflows4s/doobie/postgres/PostgresWorkflowRegistry.scala
@@ -45,8 +45,9 @@ object PostgresWorkflowRegistry {
       clock: Clock = Clock.systemUTC(),
       keepFinished: Boolean = false,
       taggers: Map[String, WorkflowRegistry.Tagger[?]] = Map.empty,
+      claimTimeout: FiniteDuration = 1.minute,
   ): IO[PostgresWorkflowRegistry] =
-    IO(new Impl(xa, tableName, pollInterval, clock, keepFinished, taggers))
+    IO(new Impl(xa, tableName, pollInterval, clock, keepFinished, taggers, claimTimeout))
 
   private class Impl(
       xa: Transactor[IO],
@@ -55,6 +56,7 @@ object PostgresWorkflowRegistry {
       clock: Clock,
       keepFinished: Boolean,
       taggers: Map[String, WorkflowRegistry.Tagger[?]],
+      claimTimeout: FiniteDuration,
   ) extends PostgresWorkflowRegistry
       with StrictLogging {
 
@@ -79,7 +81,7 @@ object PostgresWorkflowRegistry {
           sql"""INSERT INTO $tableFr (template_id, instance_id, status, created_at, updated_at, wakeup_at, tags)
                |VALUES (${id.templateId}, ${id.instanceId}, ${ExecutionStatus.Finished}, $nowTs, $nowTs, NULL, $tagsJson::jsonb)
                |ON CONFLICT (template_id, instance_id)
-               |DO UPDATE SET status = ${ExecutionStatus.Finished}, updated_at = $nowTs, wakeup_at = NULL, tags = $tagsJson::jsonb
+               |DO UPDATE SET status = ${ExecutionStatus.Finished}, updated_at = $nowTs, wakeup_at = NULL, wakeup_claimed_at = NULL, tags = $tagsJson::jsonb
                |WHERE $tableFr.updated_at <= $nowTs""".stripMargin.update.run.void
         case ExecutionStatus.Finished                           =>
           sql"""DELETE FROM $tableFr
@@ -95,13 +97,14 @@ object PostgresWorkflowRegistry {
       val query = at match {
         case Some(t) =>
           // Upsert so a wakeup can be scheduled before the engine has registered the instance.
+          // Resetting the claim marks the new wakeup as not-yet-dispatched, even if set mid-dispatch.
           sql"""INSERT INTO $tableFr (template_id, instance_id, status, created_at, updated_at, wakeup_at)
                |VALUES (${id.templateId}, ${id.instanceId}, ${ExecutionStatus.Awaiting}, $nowTs, $nowTs, ${Timestamp.from(t)})
                |ON CONFLICT (template_id, instance_id)
-               |DO UPDATE SET wakeup_at = ${Timestamp.from(t)}""".stripMargin.update.run.void
+               |DO UPDATE SET wakeup_at = ${Timestamp.from(t)}, wakeup_claimed_at = NULL""".stripMargin.update.run.void
         case None    =>
           // Plain update — don't resurrect a row deleted because the workflow finished.
-          sql"""UPDATE $tableFr SET wakeup_at = NULL
+          sql"""UPDATE $tableFr SET wakeup_at = NULL, wakeup_claimed_at = NULL
                |WHERE template_id = ${id.templateId} AND instance_id = ${id.instanceId}""".stripMargin.update.run.void
       }
       query.transact(xa)
@@ -115,22 +118,40 @@ object PostgresWorkflowRegistry {
         .awakeEvery[IO](pollInterval)
         .evalMap(_ => dispatchDue(wakeUp).handleErrorWith(e => IO(logger.error("Poller tick failed", e))))
 
-    // Single UPDATE...RETURNING atomically claims all due rows; concurrent pollers can't double-fire because the WHERE filters out NULL wakeups.
-    // Trade-off: a wakeup whose claim commits but whose callback is cancelled (shutdown, fiber interrupt) or fails is lost — the row's wakeup_at
-    // is already NULL. Such workflows are expected to be re-woken by other mechanisms (engine startup scan, incoming signals).
+    // Single UPDATE...RETURNING atomically leases all due rows by stamping `wakeup_claimed_at`; concurrent pollers can't double-fire because the
+    // WHERE skips rows with a live claim. `wakeup_at` is cleared only after the callback succeeds, so a dispatch that fails or dies mid-flight
+    // (shutdown, fiber interrupt, callback error) is retried: on failure the claim is released eagerly, on process death it expires after
+    // `claimTimeout` and the row becomes due again. Spurious re-deliveries are safe — waking a workflow with nothing due is a no-op.
     private def dispatchDue(wakeUp: WorkflowInstanceId => IO[Unit]): IO[Unit] = {
-      val nowTs = Timestamp.from(Instant.now(clock))
-      sql"""UPDATE $tableFr SET wakeup_at = NULL
-           |WHERE wakeup_at IS NOT NULL AND wakeup_at <= $nowTs""".stripMargin.update
-        .withGeneratedKeys[(String, String)]("template_id", "instance_id")
+      val now            = Instant.now(clock)
+      val nowTs          = Timestamp.from(now)
+      val claimExpiredTs = Timestamp.from(now.minusMillis(claimTimeout.toMillis))
+      sql"""UPDATE $tableFr SET wakeup_claimed_at = $nowTs
+           |WHERE wakeup_at IS NOT NULL AND wakeup_at <= $nowTs
+           |  AND (wakeup_claimed_at IS NULL OR wakeup_claimed_at <= $claimExpiredTs)""".stripMargin.update
+        .withGeneratedKeys[(String, String, Timestamp, Timestamp)]("template_id", "instance_id", "wakeup_at", "wakeup_claimed_at")
         .compile
         .toList
         .transact(xa)
-        .flatMap(_.parTraverse_ { case (tpl, inst) =>
+        .flatMap(_.parTraverse_ { case (tpl, inst, dueAt, claimedAt) =>
           val id = WorkflowInstanceId(tpl, inst)
-          IO(logger.debug(s"Dispatching wakeup for $id")) *> wakeUp(id)
+          (IO(logger.debug(s"Dispatching wakeup for $id")) *> wakeUp(id) *> completeDispatch(id, dueAt, claimedAt))
+            .handleErrorWith(err => IO(logger.error(s"Wakeup dispatch failed for $id, will retry", err)) *> releaseClaim(id, claimedAt))
         })
     }
+
+    // The guards on `wakeup_at` and `wakeup_claimed_at` make this a no-op if the callback (or anyone else) scheduled a new wakeup mid-dispatch.
+    private def completeDispatch(id: WorkflowInstanceId, dueAt: Timestamp, claimedAt: Timestamp): IO[Unit] =
+      sql"""UPDATE $tableFr SET wakeup_at = NULL, wakeup_claimed_at = NULL
+           |WHERE template_id = ${id.templateId} AND instance_id = ${id.instanceId}
+           |  AND wakeup_at = $dueAt AND wakeup_claimed_at = $claimedAt""".stripMargin.update.run.void.transact(xa)
+
+    private def releaseClaim(id: WorkflowInstanceId, claimedAt: Timestamp): IO[Unit] =
+      sql"""UPDATE $tableFr SET wakeup_claimed_at = NULL
+           |WHERE template_id = ${id.templateId} AND instance_id = ${id.instanceId}
+           |  AND wakeup_claimed_at = $claimedAt""".stripMargin.update.run.void
+        .transact(xa)
+        .handleErrorWith(err => IO(logger.warn(s"Failed to release wakeup claim for $id, it will expire after $claimTimeout", err)))
 
     override def getExecutingWorkflows(notUpdatedFor: FiniteDuration): fs2.Stream[ConnectionIO, WorkflowInstanceId] =
       for {

--- a/workflows4s-doobie/src/test/scala/workflows4s/doobie/postgres/PostgresWorkflowRegistryTest.scala
+++ b/workflows4s-doobie/src/test/scala/workflows4s/doobie/postgres/PostgresWorkflowRegistryTest.scala
@@ -15,7 +15,8 @@ import workflows4s.runtime.registry.{WorkflowRegistry, WorkflowSearch}
 import workflows4s.utils.StringUtils
 import workflows4s.wio.{ActiveWorkflow, WIO, WorkflowContext}
 
-import java.util.concurrent.atomic.AtomicReference
+import java.sql.Timestamp
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 import scala.concurrent.duration.DurationInt
 
 class PostgresWorkflowRegistryTest extends AnyFreeSpec with PostgresSuite with Matchers with BeforeAndAfterEach {
@@ -130,6 +131,116 @@ class PostgresWorkflowRegistryTest extends AnyFreeSpec with PostgresSuite with M
           .transact(xa)
           .unsafeRunSync()
         assert(remaining === 0)
+      }
+
+      "should retry a wakeup whose callback fails" in {
+        val clock    = TestClock()
+        val registry = PostgresWorkflowRegistry(xa = xa, pollInterval = 100.millis, clock = clock).unsafeRunSync()
+
+        val id       = WorkflowInstanceId("tpl", "inst-fail")
+        val attempts = new AtomicInteger(0)
+        val callback = (_: WorkflowInstanceId) => IO(attempts.incrementAndGet()) *> IO.raiseError(new RuntimeException("boom"))
+
+        registry.updateWakeup(id, Some(clock.instant.minusSeconds(1))).unsafeRunSync()
+        registry
+          .initialize(callback)
+          .use(_ => IO.sleep(500.millis))
+          .unsafeRunSync()
+
+        assert(attempts.get() >= 2)
+        val (wakeupSet, claimSet) =
+          sql"SELECT wakeup_at IS NOT NULL, wakeup_claimed_at IS NOT NULL FROM workflow_registry WHERE instance_id = ${id.instanceId}"
+            .query[(Boolean, Boolean)]
+            .unique
+            .transact(xa)
+            .unsafeRunSync()
+        assert(wakeupSet === true)
+        assert(claimSet === false)
+      }
+
+      "should not double-dispatch while a claim is live" in {
+        val clock    = TestClock()
+        val registry = PostgresWorkflowRegistry(xa = xa, pollInterval = 100.millis, clock = clock).unsafeRunSync()
+
+        val id         = WorkflowInstanceId("tpl", "inst-claimed")
+        val dispatched = new AtomicInteger(0)
+
+        registry.updateWakeup(id, Some(clock.instant.minusSeconds(1))).unsafeRunSync()
+        sql"UPDATE workflow_registry SET wakeup_claimed_at = ${Timestamp.from(clock.instant)} WHERE instance_id = ${id.instanceId}".update.run
+          .transact(xa)
+          .unsafeRunSync()
+
+        registry
+          .initialize(_ => IO(dispatched.incrementAndGet()).void)
+          .use(_ => IO.sleep(500.millis))
+          .unsafeRunSync()
+
+        assert(dispatched.get() === 0)
+      }
+
+      "should re-dispatch after a claim expires" in {
+        val clock    = TestClock()
+        val registry = PostgresWorkflowRegistry(xa = xa, pollInterval = 100.millis, clock = clock, claimTimeout = 1.minute).unsafeRunSync()
+
+        val id         = WorkflowInstanceId("tpl", "inst-expired")
+        val dispatched = new AtomicInteger(0)
+
+        registry.updateWakeup(id, Some(clock.instant.minusSeconds(10))).unsafeRunSync()
+        // simulate a dispatcher that claimed the row and died before completing
+        sql"UPDATE workflow_registry SET wakeup_claimed_at = ${Timestamp.from(clock.instant.minusSeconds(120))} WHERE instance_id = ${id.instanceId}".update.run
+          .transact(xa)
+          .unsafeRunSync()
+
+        registry
+          .initialize(_ => IO(dispatched.incrementAndGet()).void)
+          .use(_ => IO.sleep(500.millis))
+          .unsafeRunSync()
+
+        assert(dispatched.get() === 1)
+      }
+
+      "should preserve a wakeup registered during dispatch" in {
+        val clock    = TestClock()
+        val registry = PostgresWorkflowRegistry(xa = xa, pollInterval = 100.millis, clock = clock).unsafeRunSync()
+
+        val id       = WorkflowInstanceId("tpl", "inst-rearm")
+        // truncated to micros so the value survives the postgres timestamptz roundtrip unchanged
+        val nextTime = clock.instant.plusSeconds(3600).truncatedTo(java.time.temporal.ChronoUnit.MICROS)
+        val callback = (w: WorkflowInstanceId) => registry.updateWakeup(w, Some(nextTime))
+
+        registry.updateWakeup(id, Some(clock.instant.minusSeconds(1))).unsafeRunSync()
+        registry
+          .initialize(callback)
+          .use(_ => IO.sleep(500.millis))
+          .unsafeRunSync()
+
+        val remaining = sql"SELECT wakeup_at FROM workflow_registry WHERE instance_id = ${id.instanceId}"
+          .query[Option[Timestamp]]
+          .unique
+          .transact(xa)
+          .unsafeRunSync()
+        assert(remaining.map(_.toInstant) === Some(nextTime))
+      }
+
+      "should dispatch remaining wakeups when one callback fails" in {
+        val clock    = TestClock()
+        val registry = PostgresWorkflowRegistry(xa = xa, pollInterval = 100.millis, clock = clock).unsafeRunSync()
+
+        val failingId  = WorkflowInstanceId("tpl", "inst-bad")
+        val healthyId  = WorkflowInstanceId("tpl", "inst-good")
+        val dispatched = new AtomicReference[List[WorkflowInstanceId]](Nil)
+        val callback   = (w: WorkflowInstanceId) =>
+          if w == failingId then IO.raiseError(new RuntimeException("boom"))
+          else IO(dispatched.updateAndGet(w :: _)).void
+
+        registry.updateWakeup(failingId, Some(clock.instant.minusSeconds(1))).unsafeRunSync()
+        registry.updateWakeup(healthyId, Some(clock.instant.minusSeconds(1))).unsafeRunSync()
+        registry
+          .initialize(callback)
+          .use(_ => IO.sleep(500.millis))
+          .unsafeRunSync()
+
+        assert(dispatched.get().contains(healthyId))
       }
 
       "updateWakeup(None) should not resurrect a deleted row" in {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable timeout for workflow dispatch claim management.

* **Improvements**
  * Enhanced wakeup dispatch system with atomic claim tracking to prevent double-dispatch and automatically retry failed callbacks after timeout expiration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->